### PR TITLE
Ensure 'qs' is real whenever qs will be manipulated.

### DIFF
--- a/lib/nano.js
+++ b/lib/nano.js
@@ -189,7 +189,7 @@ module.exports = exports = nano = function dbScope(cfg) {
       return httpAgent(req);
     }
 
-    return httpAgent(req, function(e, h, b) { 
+    return httpAgent(req, function(e, h, b) {
       rh = h && h.headers || {};
       rh.statusCode = h && h.statusCode || 500;
       rh.uri = req.uri;
@@ -330,6 +330,7 @@ module.exports = exports = nano = function dbScope(cfg) {
       qs = {};
     }
 
+    qs = qs || {};
     qs.db = urlResolveFix(cfg.url, encodeURIComponent(dbName));
 
     if (typeof callback === 'function') {
@@ -514,6 +515,7 @@ module.exports = exports = nano = function dbScope(cfg) {
         callback = qs;
         qs = {};
       }
+      qs = qs || {};
 
       var viewPath = '_design/' + ddoc + '/_' + meta.type + '/'  + viewName;
 
@@ -621,6 +623,7 @@ module.exports = exports = nano = function dbScope(cfg) {
       if (typeof qs === 'string') {
         qs = {docName: qs};
       }
+      qs = qs || {};
 
       var docName = qs.docName;
       delete qs.docName;
@@ -660,6 +663,7 @@ module.exports = exports = nano = function dbScope(cfg) {
         callback = qs;
         qs = {};
       }
+      qs = qs || {};
 
       qs.attachments = true;
 


### PR DESCRIPTION
As described in https://github.com/dscape/nano/issues/313 there are a few places where the qs parameter is tested relative to being a function or string and defaulted, but no default is provided when the parameter is simply not present. This patch ensures that all methods with this pattern which subsequently try to manipulate the 'qs' variable will always have one. The patch uses the same syntax found in the current implementation of fetchDocs for consistency.

