### PR TITLE
remove unsupported versions of Node.js. …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,11 @@ branches:
     - next
     - rewrite
 node_js:
-  - "0.12"
-  - "iojs"
-  - "4.2"
   - "node"
+  - "4"
+  - "6"
+  - "7"
+
 services:
   - docker
 os:


### PR DESCRIPTION
We now test against latest stable Node, latest v4, latest v6 and latest v7.

Remove support for 0.12 as it is end-of-life.

see https://github.com/nodejs/LTS