### PR TITLE
remove extra apostrophe

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ Gets database information:
 ```js
 nano.db.info(function(err, body) {
   if (!err) {
-    console.log('got database info'', body);
+    console.log('got database info', body);
   }
 });
 ```


### PR DESCRIPTION
## Overview

Removes an extra apostrophe in the readme that causes erroneous markdown rendering on github 
