### PR TITLE
Use cloudant-follow

### DIFF
--- a/lib/nano.js
+++ b/lib/nano.js
@@ -18,7 +18,7 @@ var querystring = require('querystring');
 var request = require('request');
 var errs = require('errs');
 var _ = require('underscore');
-var follow = require('follow');
+var follow = require('cloudant-follow');
 var logger = require('./logger');
 
 var nano;


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Since package.json is now using `cloudant-follow` instead of `follow`, then the module needs to be be replaced in `lib/nano.js` as well, otherwise, the module will be broken. 

## Testing recommendations

N/A

## GitHub issue number

N/A

## Related Pull Requests

https://github.com/apache/couchdb-nano/pull/51

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
