### PR TITLE
fix request dependency to ~2.81.0 to avoid later version which breaks…

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "database"
   ],
   "dependencies": {
-    "request": "^2.76.0",
+    "request": "~2.81.0",
     "cloudant-follow": "^0.13.0",
     "errs": "^0.3.2",
     "underscore": "^1.8.3",


### PR DESCRIPTION
## Overview

Currently we depend on request version `^2.76.0`. As of recent request releases, this is pulling in a faulty version of 'hawk' (https://github.com/request/request/blob/6f1b51ed43309128487739f20f9df0699a043124/package.json#L38).

The quickest fix for this library is to lock the request dependency to `~2.81.0` which prevent the faulty version of hawk being pulled in for Nano users and nodejs-cloudant users upstream.

## Testing recommendations

No code changes. Just dependency numbers.



## Checklist

- [x] Code is written and works correctly;
