### PR TITLE
Return error if nano.db.get called with empty doc name (Fixes issue #70)

### DIFF
--- a/lib/nano.js
+++ b/lib/nano.js
@@ -456,7 +456,13 @@ module.exports = exports = nano = function dbScope(cfg) {
         qs = {};
       }
 
-      return relax({db: dbName, doc: docName, qs: qs}, callback);
+      if(!docName) {
+        if(callback)
+          callback("Invalid doc id", null);
+      }
+      else {
+        return relax({db: dbName, doc: docName, qs: qs}, callback);
+      }
     }
 
     // http://docs.couchdb.org/en/latest/api/document/common.html#head--db-docid

--- a/tests/unit/document/get.js
+++ b/tests/unit/document/get.js
@@ -1,0 +1,41 @@
+// Licensed under the Apache License, Version 2.0 (the 'License'); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+'use strict';
+
+var helpers = require('../../helpers/unit');
+var test  = require('tape');
+var debug = require('debug')('nano/tests/unit/shared/error');
+
+var cli = helpers.mockClientDb(debug)
+var db = cli.use('foo')
+
+test('it should not return db info if docName undefined', function(assert) {
+  db.get(undefined, function(err) {
+    assert.equal(err, 'Invalid doc id');
+    assert.end();
+  });
+});
+
+test('it should not return db info if docName null', function(assert) {
+  db.get(null, function(err) {
+    assert.equal(err, 'Invalid doc id');
+    assert.end();
+  });
+});
+
+test('it should not return db info if docName empty string', function(assert) {
+  db.get('', function(err) {
+    assert.equal(err, 'Invalid doc id');
+    assert.end();
+  });
+});


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Return an error instead of of db info when nano.db.get is called with an empty docName. ([Issue 70](https://github.com/apache/couchdb-nano/issues/70))

## Testing recommendations
I've created unit tests to call db.get with null, undefined and ''

## GitHub issue number
[70](https://github.com/apache/couchdb-nano/issues/70)
## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
