### PR TITLE
Update README.md - Fix link for Follow package

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ nano.db.changes('alice', function(err, body) {
 
 ### nano.db.follow(name, [params], [callback])
 
-Uses [Follow] to create a solid changes feed. Please consult `follow` documentation for more information as this is a very complete API on it's own:
+Uses [Follow](https://github.com/cloudant-labs/cloudant-follow/) to create a solid changes feed. Please consult `follow` documentation for more information as this is a very complete API on it's own:
 
 ``` js
 var feed = db.follow({since: "now"});


### PR DESCRIPTION
The link pointed to the `jhs/follow` GitHub repo when it should point to `cloudant-labs/cloudant-follow`

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
Fixes the link in the README.md file about the Follow package

## Testing recommendations
Click on the link about the Follow package in the `nano.db.follow(name, [params], [callback])` section of the README.md file

## GitHub issue number
Fixes apache/couchdb-nano#81
<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-nano/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb-nano#472".  -->

## Checklist
- [x] Documentation reflects the changes;
