### PR TITLE
Multipart get should Accept multipart/related

### DIFF
--- a/lib/nano.js
+++ b/lib/nano.js
@@ -147,6 +147,10 @@ module.exports = exports = nano = function dbScope(cfg) {
       delete req.headers.accept;
     }
 
+    if(opts.accept) {
+      req.headers['accept'] = opts.accept;
+    }
+
     // http://guide.couchdb.org/draft/security.html#cookies
     if (cfg.cookie) {
       req.headers['X-CouchDB-WWW-Authenticate'] = 'Cookie';
@@ -703,7 +707,7 @@ module.exports = exports = nano = function dbScope(cfg) {
         db: dbName,
         doc: docName,
         encoding: null,
-        contentType: 'multipart/related',
+        accept: 'multipart/related',
         qs: qs
       }, callback);
     }

--- a/tests/unit/multipart/get.js
+++ b/tests/unit/multipart/get.js
@@ -19,7 +19,7 @@ var getMultipart = require('../../helpers/unit').unit([
 
 getMultipart('space', {extra: 'stuff'}, {
   encoding: null,
-  headers: {'content-type': 'multipart/related'},
+  headers: {'accept': 'multipart/related'},
   method: 'GET',
   qs: {attachments: true, extra: 'stuff'},
   uri: '/mock/space'


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

Currently the getMultipart function sets the `Content-Type` header instead of the `Accept` header. This doesn't make sense for a `GET`. If you run `multipart.get` to get attachments against old versions of CouchDB this results in JSON being returned when it should be a `Buffer`, `multipart/related` & a `Buffer` is returned on newer versions of CouchDB because the default `Content-Type` of the response has changed.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

There is an existing test `tests/unit/multipart/get.js`, which asserts that the request comes with a `Content-Type: multipart/related` header in the same way as the `multipart/insert.js` test, but a `GET` vs `PUT` need different approaches to this.

I have updated the `GET` test to assert the `Accept` header rather than the `Content-Type` header.

## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-nano/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [x] Documentation reflects the changes; - the documentation states that the method should return a `Buffer` already, but that was not the case on old versions of CouchDB.
