### PR TITLE
63 update engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ or save `nano` as a dependency of your project with
 
     npm install --save nano
 
+Note the minimum required version of Node.js is 6.
+
 ## Table of contents
 
 - [Getting started](#getting-started)

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "main": "./lib/nano.js",
   "engines": {
-    "node": ">=0.12"
+    "node": ">=6"
   },
   "pre-commit": [
     "jshint",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "debug": "^2.2.0",
     "errs": "^0.3.2",
     "lodash.isempty": "^4.4.0",
-    "request": "~2.83.0"
+    "request": "^2.85.0"
   },
   "devDependencies": {
     "async": "^2.1.2",


### PR DESCRIPTION
## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
Updated the minimum Node.js engine in `package.json` to 6. This is currently the oldest available LTS release of Node.js. Moving to a Node.js version >4 unblocks upgrades of `request` to versions > 2.81.0 so the workaround from fc794b202bd68bef785564b35f3071b418215fcb to pin to 2.81.0 can be safely removed (although it appears that #73 already moved it to 2.83.0). With Node.js 6 it should be safe to move back to backwards compatible changes.

## Testing recommendations

`npm install` will give a warning on Node.js versions older than 6.

## GitHub issue number

#63 

## Checklist

- [x] Code is written and works correctly; - No new code `package.json` and `request` dependency version change only.
- [x] Changes are covered by tests; - tests pass locally for me.
- [x] Documentation reflects the changes; - updated `README` to mention the minimum version.
