### PR TITLE
Add optional support for native promises

### DIFF
--- a/lib/nano.js
+++ b/lib/nano.js
@@ -84,6 +84,19 @@ module.exports = exports = nano = function dbScope(cfg) {
       callback = null;
     }
 
+    if (opts.promise || (cfg.promise && opts.promise !== false)) {
+      const callbackOpts = Object.assign({}, opts, { promise: false });
+      return new Promise(function(resolve, reject) {
+        relax(callbackOpts, function(err, result) {
+          if (err) {
+            reject(err)
+          } else {
+            resolve(result)
+          }
+        })
+      });
+    }
+
     var qs = Object.assign({}, opts.qs);
 
     var headers = {
@@ -746,6 +759,23 @@ module.exports = exports = nano = function dbScope(cfg) {
       }, callback);
     }
 
+    function getAttAsStream(docName, attName, qs, callback) {
+      if (typeof qs === 'function') {
+        callback = qs;
+        qs = {};
+      }
+
+      return relax({
+        db: dbName,
+        att: attName,
+        doc: docName,
+        qs: qs,
+        encoding: null,
+        dontParse: true,
+        promise: false
+      });
+    }
+
     function destroyAtt(docName, attName, qs, callback) {
       return relax({
         db: dbName,
@@ -810,6 +840,7 @@ module.exports = exports = nano = function dbScope(cfg) {
       attachment: {
         insert: insertAtt,
         get: getAtt,
+        getAsStream: getAttAsStream,
         destroy: destroyAtt
       },
       show: showDoc,


### PR DESCRIPTION
When initializing nano or calling nano.request, it's now possible to pass a `promise: true` to have a promise returned if no callback is passed. If the `promise` flag is not set, calling a request method without callback will return a stream as before.

Here is an example:

```js
const nano = require('nano')({
  url: 'http://localhost:5984',
  promise: true
});

var db = nano.db.use('animals');

db.get('rabbit')
  .then(function(err, doc) {
    console.log('Got document:', doc);
  })
  .catch(function(err, doc) {
    console.error('An error occured!', err);
  });
```

Or using `async`-`await`:

```js
const nano = require('nano')({
  url: 'http://localhost:5984',
  promise: true
});

var db = nano.db.use('animals');

(async function() {
  try {
    var doc1 = await db.get('rabbit');
    var doc2 = await db.get('fox');
    console.log('Got documents:', doc1, doc2);
  } catch (error) {
    console.error('An error occured!', err);;
  }
})();
```

To support piping of attachments even with promise mode enabled, a new `db.attachment.getAsSteam` method was introduced.

~Note that despite the backward-compatible behavior, this is a breaking change according to semver because due to the use of native promises, at least Node.js 4.x is required to make use of `promise: true`. The minimum `package.json` version was bumped to reflect that change.~ As you just updated the engine version to >= 6, this point is moot now.