### PR TITLE
Fix in README name of the returned array when using uuids function

### DIFF
--- a/README.md
+++ b/README.md
@@ -929,7 +929,7 @@ If your application needs to generate UUIDs, then CouchDB can provide some for y
 
 ```js
 nano.uuids(3, callback);
-// { uuid: [
+// { uuids: [
 // '5d1b3ef2bc7eea51f660c091e3dffa23',
 // '5d1b3ef2bc7eea51f660c091e3e006ff',
 // '5d1b3ef2bc7eea51f660c091e3e007f0',


### PR DESCRIPTION
## Overview

Pull request fixing description of uuids function in the README file

## Testing recommendations


## GitHub issue number

There are minor changes I didn't raise issue

## Related Pull Requests