### PR TITLE
Update link to CouchDB bulk API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,7 +557,7 @@ alice.copy('rabbit', 'rabbit2', { overwrite: true }, function(err, _, headers) {
 ### db.bulk(docs, [params], [callback])
 
 Bulk operations(update/delete/insert) on the database, refer to the
-[CouchDB doc](http://wiki.apache.org/couchdb/HTTP_Bulk_Document_API) e.g:
+[CouchDB doc](http://docs.couchdb.org/en/2.1.1/api/database/bulk-api.html#db-bulk-docs) e.g:
 
 ``` js
 var documents = [


### PR DESCRIPTION
## Overview

A link in the README referred to a page on the old CouchDB wiki that no longer exists.

## Testing recommendations

N/A

## GitHub issue number

N/A

## Related Pull Requests

N/A

## Checklist

- Code is written and works correctly;
- Changes are covered by tests;
- Documentation reflects the changes;
