### PR TITLE
clone user-supplied query string object prior to mutation - issue #85

### DIFF
--- a/lib/nano.js
+++ b/lib/nano.js
@@ -551,10 +551,9 @@ module.exports = exports = nano = function dbScope(cfg) {
         callback = qs;
         qs = {};
       }
-      qs = qs || {};
 
       // prevent mutation of the client qs object by using a clone
-      qs = Object.assign({}, qs)
+      var qs1 = Object.assign({}, qs)
 
       var viewPath = '_design/' + ddoc + '/_' + meta.type + '/'  + viewName;
 
@@ -562,28 +561,28 @@ module.exports = exports = nano = function dbScope(cfg) {
       // object API, several parameters need JSON endoding.
       var paramsToEncode = ['counts', 'drilldown', 'group_sort', 'ranges', 'sort'];
       paramsToEncode.forEach(function(param) {
-        if (param in qs) {
-          if (typeof qs[param] !== 'string') {
-            qs[param] = JSON.stringify(qs[param]);
+        if (param in qs1) {
+          if (typeof qs1[param] !== 'string') {
+            qs1[param] = JSON.stringify(qs1[param]);
           } else {
             // if the parameter is not already encoded, encode it
             try {
-              JSON.parse(qs[param]);
+              JSON.parse(qs1[param]);
             } catch(e) {
-              qs[param] = JSON.stringify(qs[param]);
+              qs1[param] = JSON.stringify(qs1[param]);
             }
           }
         }
       });
 
-      if (qs && qs.keys) {
-        var body = {keys: qs.keys};
-        delete qs.keys;
+      if (qs1 && qs1.keys) {
+        var body = {keys: qs1.keys};
+        delete qs1.keys;
         return relax({
           db: dbName,
           path: viewPath,
           method: 'POST',
-          qs: qs,
+          qs: qs1,
           body: body
         }, callback);
       } else {
@@ -591,7 +590,7 @@ module.exports = exports = nano = function dbScope(cfg) {
           db: dbName,
           method: meta.method || 'GET',
           path: viewPath,
-          qs: qs
+          qs: qs1
         };
 
         if (meta.body) {

--- a/lib/nano.js
+++ b/lib/nano.js
@@ -553,6 +553,9 @@ module.exports = exports = nano = function dbScope(cfg) {
       }
       qs = qs || {};
 
+      // prevent mutation of the client qs object by using a clone
+      qs = JSON.parse(JSON.stringify(qs))
+
       var viewPath = '_design/' + ddoc + '/_' + meta.type + '/'  + viewName;
 
       // Several search parameters must be JSON-encoded; but since this is an

--- a/lib/nano.js
+++ b/lib/nano.js
@@ -554,7 +554,7 @@ module.exports = exports = nano = function dbScope(cfg) {
       qs = qs || {};
 
       // prevent mutation of the client qs object by using a clone
-      qs = JSON.parse(JSON.stringify(qs))
+      qs = Object.assign({}, qs)
 
       var viewPath = '_design/' + ddoc + '/_' + meta.type + '/'  + viewName;
 


### PR DESCRIPTION
## Overview

A user-supplied query string object could be mutated by this library's `view` function. Code changed to clone the object prior to using it.

## Testing recommendations

See issue #85

## GitHub issue number

Issue #85 

## Related Pull Requests

n/a

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [x] Documentation reflects the changes;
