### PR TITLE
Promise support for Nano - Issue 98

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -3,11 +3,12 @@
   "node":      true,
   "strict":    true,
   "smarttabs": true,
-  "maxlen":    80,
+  "maxlen":    100,
   "newcap":    false,
   "undef":     true,
   "unused":    true,
   "onecase":   true,
   "indent":    2,
-  "sub":       true
+  "sub":       true,
+  "esnext":    true
 }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ Features:
 
 * **Minimalistic** - There is only a minimum of abstraction between you and
   CouchDB.
-* **Pipes** - Proxy requests from CouchDB directly to your end user.
+* **Pipes** - Proxy requests from CouchDB directly to your end user. ( `...AsStream` functions only)
+* **Promises** - The vast majority of library calls return native Promises.
+* **TypeScript** - Detailed TypeScript definitions are built in.
 * **Errors** - Errors are proxied directly from CouchDB: if you know CouchDB
   you already know `nano`.
 
@@ -22,6 +24,8 @@ or save `nano` as a dependency of your project with
     npm install --save nano
 
 Note the minimum required version of Node.js is 6.
+
+See [Migration Guide for switching from Nano 6.x to 7.x](migration_6_to_7.md).
 
 ## Table of contents
 
@@ -73,6 +77,7 @@ Note the minimum required version of Node.js is 6.
   - [db.show(designname, showname, doc_id, [params], [callback])](#dbshowdesignname-showname-doc_id-params-callback)
   - [db.atomic(designname, updatename, docname, [body], [callback])](#dbatomicdesignname-updatename-docname-body-callback)
   - [db.search(designname, viewname, [params], [callback])](#dbsearchdesignname-searchname-params-callback)
+  - [db.find(selector, [callback])](#dbfindselector-callback)
 - [Using cookie authentication](#using-cookie-authentication)
 - [Advanced features](#advanced-features)
   - [getting uuids](#getting-uuids)
@@ -891,6 +896,25 @@ alice.search('characters', 'happy_ones', { q: 'cat' }).then((doc) => {
 ```
 
 Check out the tests for a fully functioning example.
+
+### db.find(selector, [callback])
+
+Perform a ["Mango" query](http://docs.couchdb.org/en/2.1.1/api/database/find.html) by supplying a JavaScript object containing a selector:
+
+```js
+// find documents where the name = "Brian" and age > 25.
+var q = { 
+  selector: {
+    name: { "$eq": "Brian"},
+    age : { "$gt": 25 }
+  },
+  fields: [ "name", "age", "tags", "url" ]
+  limit:50
+};
+alice.find(q).then((doc) => {
+  console.log(doc);
+});
+```
 
 ## using cookie authentication
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ See [Migration Guide for switching from Nano 6.x to 7.x](migration_6_to_7.md).
   - [db.atomic(designname, updatename, docname, [body], [callback])](#dbatomicdesignname-updatename-docname-body-callback)
   - [db.search(designname, viewname, [params], [callback])](#dbsearchdesignname-searchname-params-callback)
   - [db.find(selector, [callback])](#dbfindselector-callback)
+  - [db.findAsStream(selector, [callback])](#dbfindasstreamselector-callback)
 - [Using cookie authentication](#using-cookie-authentication)
 - [Advanced features](#advanced-features)
   - [getting uuids](#getting-uuids)
@@ -914,6 +915,23 @@ var q = {
 alice.find(q).then((doc) => {
   console.log(doc);
 });
+```
+
+### db.findAsStream(selector, [callback])
+
+Perform a ["Mango" query](http://docs.couchdb.org/en/2.1.1/api/database/find.html) by supplying a JavaScript object containing a selector, but return a stream:
+
+```js
+// find documents where the name = "Brian" and age > 25.
+var q = { 
+  selector: {
+    name: { "$eq": "Brian"},
+    age : { "$gt": 25 }
+  },
+  fields: [ "name", "age", "tags", "url" ]
+  limit:50
+};
+alice.findAsStream(q).pipe(process.stdout);
 ```
 
 ## using cookie authentication

--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ See [Migration Guide for switching from Nano 6.x to 7.x](migration_6_to_7.md).
   - [db.view(designname, viewname, [params], [callback])](#dbviewdesignname-viewname-params-callback)
   - [db.show(designname, showname, doc_id, [params], [callback])](#dbshowdesignname-showname-doc_id-params-callback)
   - [db.atomic(designname, updatename, docname, [body], [callback])](#dbatomicdesignname-updatename-docname-body-callback)
-  - [db.search(designname, viewname, [params], [callback])](#dbsearchdesignname-searchname-params-callback)
+  - [db.search(designname, viewname, params, [callback])](#dbsearchdesignname-searchname-params-callback)
+  - [db.searchAsStream(designname, viewname, params, [callback])](#dbsearchasstreamdesignname-searchname-params-callback)
   - [db.find(selector, [callback])](#dbfindselector-callback)
   - [db.findAsStream(selector, [callback])](#dbfindasstreamselector-callback)
 - [Using cookie authentication](#using-cookie-authentication)
@@ -886,7 +887,7 @@ An example update handler follows:
 }
 ```
 
-### db.search(designname, searchname, [params], [callback])
+### db.search(designname, searchname, params, [callback])
 
 Calls a view of the specified design with optional query string additions `params`.
 
@@ -897,6 +898,14 @@ alice.search('characters', 'happy_ones', { q: 'cat' }).then((doc) => {
 ```
 
 Check out the tests for a fully functioning example.
+
+### db.searchAsStream(designname, searchname, params, [callback])
+
+Calls a view of the specified design with optional query string additions `params`. Returns stream.
+
+```js
+alice.search('characters', 'happy_ones', { q: 'cat' }).pipe(process.stdout);
+```
 
 ### db.find(selector, [callback])
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ See [Migration Guide for switching from Nano 6.x to 7.x](migration_6_to_7.md).
 To use `nano` you need to connect it to your CouchDB install, to do that:
 
 ```js
-var nano = require('nano')('http://localhost:5984');
+const nano = require('nano')('http://localhost:5984');
 ```
 
 The URL you supply may also contain authenication credentials e.g. `http://admin:mypassword@localhost:5984`.
@@ -109,7 +109,7 @@ nano.db.create('alice');
 and to use an existing database:
 
 ```js
-var alice = nano.db.use('alice');
+const alice = nano.db.use('alice');
 ```
 
 Under-the-hood, calls like `nano.db.create` are making HTTP API calls to the CouchDB service. Such operations are *asynchronous*. There are two ways to recieve the asynchronous data back from the library
@@ -147,8 +147,8 @@ The documentation will now follow the *Promises* style.
 A simple but complete example is:
 
 ```js
-var nano = require('nano')('http://localhost:5984');
-var alice = null;
+const nano = require('nano')('http://localhost:5984');
+let alice;
 
 nano.db.destory('alice').then((response) => {
   return nano.db.create('alice')
@@ -190,29 +190,29 @@ You can also see your document in [futon](http://localhost:5984/_utils).
 Configuring nano to use your database server is as simple as:
 
 ```js
-var nano = require('nano')('http://localhost:5984'),
-  db = nano.use('foo');
+const nano = require('nano')('http://localhost:5984')
+const db = nano.use('foo');
 ```
 
 If you don't need to instrument database objects you can simply:
 
 ```js
 // nano parses the URL and knows this is a database
-var db = require('nano')('http://localhost:5984/foo');
+const db = require('nano')('http://localhost:5984/foo');
 ```
 
 You can also pass options to the require to specify further configuration options you can pass an object literal instead:
 
 ```js
 // nano parses the URL and knows this is a database
-var opts = {
+const opts = {
   url: "http://localhost:5984/foo",
   requestDefaults: { "proxy" : "http://someproxy" },
   log: (id, args) => {
     console.log(id, args);
   }
 };
-var db = require('nano')(opts);
+const db = require('nano')(opts);
 ```
 
 Please check [request] for more information on the defaults. They support features like cookie jar, proxies, ssl, etc.
@@ -222,11 +222,11 @@ You can tell nano to not parse the URL (maybe the server is behind a proxy, is a
 ```js
 // nano does not parse the URL and return the server api
 // "http://localhost:5984/prefix" is the CouchDB server root
-var couch = require('nano')(
+const couch = require('nano')(
   { url : "http://localhost:5984/prefix"
     parseUrl : false
   });
-var db = couch.use('foo');
+const db = couch.use('foo');
 ```
 
 ### Pool size and open sockets
@@ -242,14 +242,14 @@ You can also increase the size in your calling context using `requestDefaults` i
 Here's an example explicitly using the keep alive agent (installed using `npm install agentkeepalive`), especially useful to limit your open sockets when doing high-volume access to CouchDB on localhost:
 
 ```js
-var agentkeepalive = require('agentkeepalive');
-var myagent = new agentkeepalive({
+const agentkeepalive = require('agentkeepalive');
+const myagent = new agentkeepalive({
   maxSockets: 50,
   maxKeepAliveRequests: 0,
   maxKeepAliveTime: 30000
 });
 
-var db = require('nano')(
+const db = require('nano')(
   { url: "http://localhost:5984/foo",
     requestDefaults : { "agent" : myagent }
   });
@@ -433,7 +433,7 @@ nano.db.changes('alice').pipe(process.stdout);
 Uses [Follow] to create a solid changes feed. Please consult `follow` documentation for more information as this is a very complete API on it's own:
 
 ```js
-var feed = db.follow({since: "now"});
+const feed = db.follow({since: "now"});
 feed.on('change', (change) => {
   console.log("change: ", change);
 });
@@ -458,7 +458,7 @@ nano.db.info().then((body) => {
 Returns a database object that allows you to perform operations against that database:
 
 ```js
-var alice = nano.use('alice');
+const alice = nano.use('alice');
 alice.insert({ happy: true }, 'rabbit').then((body) => {
   // do something
 });
@@ -526,7 +526,7 @@ Use [Follow] to create a solid
 Please consult follow documentation for more information as this is a very complete api on it's own
 
 ```js
-var feed = nano.followUpdates({since: "now"});
+const feed = nano.followUpdates({since: "now"});
 feed.on('change', (change) => {
   console.log("change: ", change);
 });
@@ -543,7 +543,7 @@ process.nextTick( () => {
 Inserts `doc` in the database with optional `params`. If params is a string, it's assumed it is the intended document `_id`. If params is an object, it's passed as query string parameters and `docName` is checked for defining the document `_id`:
 
 ```js
-var alice = nano.use('alice');
+const alice = nano.use('alice');
 alice.insert({ happy: true }, 'rabbit').then((body) => {
   console.log(body);
 });
@@ -552,7 +552,7 @@ alice.insert({ happy: true }, 'rabbit').then((body) => {
 The `insert` function can also be used with the method signature `db.insert(doc,[callback])`, where the `doc` contains the `_id` field e.g.
 
 ```js
-var alice = nano.use('alice')
+const alice = nano.use('alice')
 alice.insert({ _id: 'myid', happy: true }).then((body) => {
   console.log(body)
 })
@@ -561,7 +561,7 @@ alice.insert({ _id: 'myid', happy: true }).then((body) => {
 and also used to update an existing document, by including the `_rev` token in the document being saved:
 
 ```js
-var alice = nano.use('alice')
+const alice = nano.use('alice')
 alice.insert({ _id: 'myid', _rev: '1-23202479633c2b380f79507a776743d5', happy: false }).then((body) => {
   console.log(body)
 })
@@ -624,7 +624,7 @@ Bulk operations(update/delete/insert) on the database, refer to the
 [CouchDB doc](http://docs.couchdb.org/en/2.1.1/api/database/bulk-api.html#db-bulk-docs) e.g:
 
 ```js
-var documents = [
+const documents = [
   { a:1, b:2 },
   { _id: 'tiger', striped: true}
 ];
@@ -672,7 +672,7 @@ additional query string `params` can be specified, `include_docs` is always set
 to `true`.
 
 ```js
-var keys = ['tiger', 'zebra', 'donkey'];
+const keys = ['tiger', 'zebra', 'donkey'];
 alice.fetch({keys: keys}).then((data) => {
   console.log(data);
 });
@@ -693,7 +693,7 @@ Create index on database fields, as specified in
 [CouchDB doc](http://docs.couchdb.org/en/latest/api/database/find.html#db-index).
 
 ```js
-var indexDef = {
+const indexDef = {
   index: { fields: ['foo'] },
   name: 'fooindex'
 };
@@ -898,7 +898,7 @@ An example update handler follows:
   "in-place" : "function(doc, req) {
       var field = req.form.field;
       var value = req.form.value;
-      var message = 'set '+field+' to '+value;
+      var message = 'set ' + field + ' to ' + value;
       doc[field] = value;
       return [doc, message];
   }"
@@ -931,7 +931,7 @@ Perform a ["Mango" query](http://docs.couchdb.org/en/2.1.1/api/database/find.htm
 
 ```js
 // find documents where the name = "Brian" and age > 25.
-var q = { 
+const q = { 
   selector: {
     name: { "$eq": "Brian"},
     age : { "$gt": 25 }
@@ -950,7 +950,7 @@ Perform a ["Mango" query](http://docs.couchdb.org/en/2.1.1/api/database/find.htm
 
 ```js
 // find documents where the name = "Brian" and age > 25.
-var q = { 
+const q = { 
   selector: {
     name: { "$eq": "Brian"},
     age : { "$gt": 25 }
@@ -1035,9 +1035,9 @@ getrabbitrev('4-2e6cdc4c7e26b745c2881a24e0eeece2').then((body) => {
 You can pipe the return values of certain nano functions like other stream. For example if our `rabbit` document has an attachment with name `picture.png` you can pipe it to a `writable stream`:
 
 ```js
-var fs = require('fs'),
-    nano = require('nano')('http://127.0.0.1:5984/');
-var alice = nano.use('alice');
+const fs = require('fs');
+const nano = require('nano')('http://127.0.0.1:5984/');
+const alice = nano.use('alice');
 alice.attachment.getAsStream('rabbit', 'picture.png').pipe(fs.createWriteStream('/tmp/rabbit.png'));
 ```
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ See [Migration Guide for switching from Nano 6.x to 7.x](migration_6_to_7.md).
   - [nano.db.replication.query(id, [opts], [callback])](#nanodbreplicationenablesource-target-opts-callback)
   - [nano.db.replication.disable(id, [opts], [callback])](#nanodbreplicationdisableid-opts-callback)
   - [nano.db.changes(name, [params], [callback])](#nanodbchangesname-params-callback)
+  - [nano.db.changesAsStream(name, [params], [callback])](#nanodbchangesasstreamname-params-callback)
   - [nano.db.follow(name, [params], [callback])](#nanodbfollowname-params-callback)
   - [nano.db.info([callback])](#nanodbinfocallback)
   - [nano.use(name)](#nanousename)
@@ -417,6 +418,14 @@ to the query string.
 nano.db.changes('alice').then((body) => {
   console.log(body);
 });
+```
+
+### nano.db.changesAsStream(name, [params], [callback])
+
+Sames as `nano.db.changes` but returns a stream.
+
+```js
+nano.db.changes('alice').pipe(process.stdout);
 ```
 
 ### nano.db.follow(name, [params], [callback])

--- a/README.md
+++ b/README.md
@@ -144,7 +144,20 @@ The documentation will now follow the *Promises* style.
 ------------------
 
 
-A simple but complete example is:
+A simple but complete example in the [async/await](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function) style:
+
+```js
+async function asyncCall() {
+  await nano.db.destory('alice')
+  await nano.db.create('alice')
+  const alice = nano.use('alice')
+  const response = await alice.insert({ happy: true }, 'rabbit')
+  return response
+}
+asyncCall()
+```
+
+or in the raw Promises-style
 
 ```js
 const nano = require('nano')('http://localhost:5984');
@@ -159,19 +172,6 @@ nano.db.destory('alice').then((response) => {
   console.log('you have inserted a document with an _id of rabbit')
   console.log(response);
 })
-```
-
-or in the `async/await` style:
-
-```js
-async function asyncCall() {
-  await nano.db.destory('alice')
-  await nano.db.create('alice')
-  const alice = nano.use('alice')
-  const response = await alice.insert({ happy: true }, 'rabbit')
-  return response
-}
-asyncCall()
 ```
 
 If you run either of these examples (after starting CouchDB) you will see:

--- a/README.md
+++ b/README.md
@@ -246,6 +246,49 @@ var db = require('nano')(
   });
 ```
 
+## TypeScript
+
+There is a full TypeScript definition included in the the *nano* package. Your TypeScript editor will show you hints as you write your code with the *nano* library with your own custom classes:
+
+```ts
+import * as Nano  from 'nano'
+
+let n = Nano('http://USERNAME:PASSSWORD@localhost:5984')
+let db = n.db.use('people')
+
+interface iPerson extends Nano.MaybeDocument {
+  name: string,
+  dob: string
+}
+
+class Person implements iPerson {
+  _id: string
+  _rev: string
+  name: string
+  dob: string
+
+  constructor(name: string, dob: string) {
+    this._id = undefined
+    this._rev = undefined
+    this.name = name
+    this.dob = dob
+  }
+
+  processAPIResponse(response: nano.DocumentInsertResponse) {
+    if (response.ok === true) {
+      this._id = response.id
+      this._rev = response.rev
+    }
+  }
+}
+
+let p = new Person('Bob', '2015-02-04')
+db.insert(p).then((response) => {
+  p.processAPIResponse(response)
+  console.log(p)
+})
+```
+
 ## Database functions
 
 ### nano.db.create(name, [callback])

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ See [Migration Guide for switching from Nano 6.x to 7.x](migration_6_to_7.md).
   - [db.attachment.destroy(docname, attname, [params], [callback])](#dbattachmentdestroydocname-attname-rev-callback)
 - [Views and design functions](#views-and-design-functions)
   - [db.view(designname, viewname, [params], [callback])](#dbviewdesignname-viewname-params-callback)
+  - [db.viewAsStream(designname, viewname, [params], [callback])](#dbviewasstreamdesignname-viewname-params-callback)
   - [db.show(designname, showname, doc_id, [params], [callback])](#dbshowdesignname-showname-doc_id-params-callback)
   - [db.atomic(designname, updatename, docname, [body], [callback])](#dbatomicdesignname-updatename-docname-body-callback)
   - [db.search(designname, viewname, params, [callback])](#dbsearchdesignname-searchname-params-callback)
@@ -835,6 +836,14 @@ alice.view('characters', 'happy_ones', { include_docs: true }).then((body) => {
     console.log(doc.value);
   });
 });
+```
+
+### db.viewAsStream(designname, viewname, [params], [callback])
+
+Same as `db.view` but returns a stream:
+
+```js
+alice.view('characters', 'happy_ones', {reduce: false}).pipe(process.stdout);
 ```
 
 ### db.viewWithList(designname, viewname, listname, [params], [callback])

--- a/README.md
+++ b/README.md
@@ -62,7 +62,9 @@ Note the minimum required version of Node.js is 6.
   - [db.multipart.get(docname, [params], [callback])](#dbmultipartgetdocname-params-callback)
 - [Attachments functions](#attachments-functions)
   - [db.attachment.insert(docname, attname, att, contenttype, [params], [callback])](#dbattachmentinsertdocname-attname-att-contenttype-params-callback)
+  - [db.attachment.insertAsStream(docname, attname, att, contenttype, [params], [callback])](#dbattachmentinsertasstreamdocname-attname-att-contenttype-params-callback)
   - [db.attachment.get(docname, attname, [params], [callback])](#dbattachmentgetdocname-attname-params-callback)
+  - [db.attachment.getAsStream(docname, attname, [params], [callback])](#dbattachmentgetasstreamdocname-attname-params-callback)
   - [db.attachment.destroy(docname, attname, [params], [callback])](#dbattachmentdestroydocname-attname-rev-callback)
 - [Views and design functions](#views-and-design-functions)
   - [db.view(designname, viewname, [params], [callback])](#dbviewdesignname-viewname-params-callback)
@@ -81,7 +83,7 @@ Note the minimum required version of Node.js is 6.
 
 To use `nano` you need to connect it to your CouchDB install, to do that:
 
-``` js
+```js
 var nano = require('nano')('http://localhost:5984');
 ```
 
@@ -89,18 +91,35 @@ The URL you supply may also contain authenication credentials e.g. `http://admin
 
 To create a new database:
 
-``` js
+```js
 nano.db.create('alice');
 ```
 
 and to use an existing database:
 
-``` js
+```js
 var alice = nano.db.use('alice');
 ```
 
-In this examples we didn't specify a `callback` function, the absence of a
-callback means _"do this, ignore what happens"_.
+Under-the-hood, calls like `nano.db.create` are making HTTP API calls to the CouchDB service. Such operations are *asynchronous*. There are two ways to recieve the asynchronous data back from the library
+
+1) Promises
+
+```js
+nano.db.create('alice').then((data) => {
+  // success - response is in 'data'
+}).catch((err) => {
+  // failure - error information is in 'err'
+})
+```
+
+2) Callbacks
+
+```js
+nano.db.create('alice', (err, data) => {
+  // errors are in 'err' & response is in 'data'
+})
+```
 
 In `nano` the callback function receives always three arguments:
 
@@ -109,35 +128,45 @@ In `nano` the callback function receives always three arguments:
   JSON parsed body, binary for non JSON responses.
 * `header` - The HTTP _response header_ from CouchDB, if no error.
 
+The documentation will now follow the *Promises* style.
 
-A simple but complete example using callbacks is:
+------------------
 
-``` js
+
+A simple but complete example is:
+
+```js
 var nano = require('nano')('http://localhost:5984');
+var alice = null;
 
-// clean up the database we created previously
-nano.db.destroy('alice', function() {
-  // create a new database
-  nano.db.create('alice', function() {
-    // specify the database we are going to use
-    var alice = nano.use('alice');
-    // and insert a document in it
-    alice.insert({ happy: true }, 'rabbit', function(err, body, header) {
-      if (err) {
-        console.log('[alice.insert] ', err.message);
-        return;
-      }
-      console.log('you have inserted the rabbit.')
-      console.log(body);
-    });
-  });
-});
+nano.db.destory('alice').then((response) => {
+  return nano.db.create('alice')
+}).then((response) =>  {
+  alice = nano.use('alice')
+  return alice.insert({ happy: true }, 'rabbit')
+}).then((response) => {
+  console.log('you have inserted a document with an _id of rabbit')
+  console.log(response);
+})
 ```
 
-If you run this example (after starting CouchDB) you will see:
+or in the `async/await` style:
+
+```js
+async function asyncCall() {
+  await nano.db.destory('alice')
+  await nano.db.create('alice')
+  const alice = nano.use('alice')
+  const response = await alice.insert({ happy: true }, 'rabbit')
+  return response
+}
+asyncCall()
+```
+
+If you run either of these examples (after starting CouchDB) you will see:
 
 ```
-you have inserted the rabbit.
+you have inserted a document with an _id of rabbitt.
 { ok: true,
   id: 'rabbit',
   rev: '1-6e4cb465d49c0368ac3946506d26335d' }
@@ -145,47 +174,30 @@ you have inserted the rabbit.
 
 You can also see your document in [futon](http://localhost:5984/_utils).
 
-## Promises
-
-Although `nano` is written using the "callback" style, it is easy enough to switch to a "Promises" style, using the [Bluebird](https://www.npmjs.com/package/bluebird) library:
-
-```js
-var Promise = require('bluebird');
-var mydb = require('nano')('http://localhost:5984/animaldb');
-
-// create Promise-compatible versions of all functions
-Promise.promisifyAll(mydb);
-
-// now we have "get" (callback compatible) and "getAsync" (Promise compatible)
-animals.getAsync('doc1').then(function(doc) {
-  console.log('the doc is', doc);
-}).catch(console.error);
-```
-
 ## Configuration
 
 Configuring nano to use your database server is as simple as:
 
-``` js
+```js
 var nano = require('nano')('http://localhost:5984'),
   db = nano.use('foo');
 ```
 
 If you don't need to instrument database objects you can simply:
 
-``` js
+```js
 // nano parses the URL and knows this is a database
 var db = require('nano')('http://localhost:5984/foo');
 ```
 
 You can also pass options to the require to specify further configuration options you can pass an object literal instead:
 
-``` js
+```js
 // nano parses the URL and knows this is a database
 var opts = {
   url: "http://localhost:5984/foo",
   requestDefaults: { "proxy" : "http://someproxy" },
-  log: function(id, args) {
+  log: (id, args) => {
     console.log(id, args);
   }
 };
@@ -210,7 +222,7 @@ var db = couch.use('foo');
 
 A very important configuration parameter if you have a high traffic website and are using `nano` is setting up the `pool.size`. By default, the Node.js HTTP global agent (client) has a certain size of active connections that can run simultaneously, while others are kept in a queue. Pooling can be disabled by setting the `agent` property in `requestDefaults` to `false`, or adjust the global pool size using:
 
-``` js
+```js
 http.globalAgent.maxSockets = 20;
 ```
 
@@ -218,7 +230,7 @@ You can also increase the size in your calling context using `requestDefaults` i
 
 Here's an example explicitly using the keep alive agent (installed using `npm install agentkeepalive`), especially useful to limit your open sockets when doing high-volume access to CouchDB on localhost:
 
-``` js
+```js
 var agentkeepalive = require('agentkeepalive');
 var myagent = new agentkeepalive({
   maxSockets: 50,
@@ -238,43 +250,40 @@ var db = require('nano')(
 
 Creates a CouchDB database with the given `name`:
 
-``` js
-nano.db.create('alice', function(err, body) {
-  if (!err) {
-    console.log('database alice created!');
-  }
-});
+```js
+nano.db.create('alice').then((body) => {
+  console.log('database alice created!');
+})
 ```
 
 ### nano.db.get(name, [callback])
 
 Get information about the database `name`:
 
-``` js
-nano.db.get('alice', function(err, body) {
-  if (!err) {
-    console.log(body);
-  }
-});
+```js
+nano.db.get('alice').then((body) => {
+  console.log(body);
+})
 ```
 
 ### nano.db.destroy(name, [callback])
 
 Destroys the database `name`:
 
-``` js
-nano.db.destroy('alice', function(err, body){
-});
+```js
+nano.db.destroy('alice').then((body) => {
+  // database destroyed
+})
 ```
 
 ### nano.db.list([callback])
 
 Lists all the CouchDB databases:
 
-``` js
-nano.db.list(function(err, body) {
+```js
+nano.db.list().then((body) => {
   // body is an array
-  body.forEach(function(db) {
+  body.forEach((db) => {
     console.log(db);
   });
 });
@@ -290,11 +299,10 @@ Replicates `source` to `target` with options `opts`. The `target`database
 has to exist, add `create_target:true` to `opts` to create it prior to
 replication:
 
-``` js
+```js
 nano.db.replicate('alice', 'http://admin:password@otherhost.com:5984/alice',
-                  { create_target:true }, function(err, body) {
-    if (!err)
-      console.log(body);
+                  { create_target:true }).then((body) => {
+  console.log(body);
 });
 ```
 
@@ -304,11 +312,10 @@ Enables replication using the new CouchDB api from `source` to `target`
 with options `opts`. `target` has to exist, add `create_target:true` to
 `opts` to create it prior to replication. Replication will survive server restarts.
 
-``` js
+```js
 nano.db.replication.enable('alice', 'http://admin:password@otherhost.com:5984/alice',
-                  { create_target:true }, function(err, body) {
-    if (!err)
-      console.log(body);
+                  { create_target:true }).then((body) => {
+  console.log(body);
 });
 ```
 
@@ -317,15 +324,12 @@ nano.db.replication.enable('alice', 'http://admin:password@otherhost.com:5984/al
 Queries the state of replication using the new CouchDB API. The `id` comes from the response
 given by the call to `replication.enable`:
 
-``` js
+```js
 nano.db.replication.enable('alice', 'http://admin:password@otherhost.com:5984/alice',
-                   { create_target:true }, function(err, body) {
-    if (!err) {
-      nano.db.replication.query(body.id, function(error, reply) {
-        if (!err)
-          console.log(reply);
-      }
-    }
+                   { create_target:true }).then((body) => {
+  return nano.db.replication.query(body.id);
+}).then((response) => {
+  console.log(response);
 });
 ```
 
@@ -334,15 +338,12 @@ nano.db.replication.enable('alice', 'http://admin:password@otherhost.com:5984/al
 Disables replication using the new CouchDB API. The `id` comes from the response given
 by the call to `replication.enable`:
 
-``` js
+```js
 nano.db.replication.enable('alice', 'http://admin:password@otherhost.com:5984/alice',
-                   { create_target:true }, function(err, body) {
-    if (!err) {
-      nano.db.replication.disable(body.id, function(error, reply) {
-        if (!err)
-          console.log(reply);
-      }
-    }
+                   { create_target:true }).then((body) => {
+  return nano.db.replication.disable(body.id);
+}).then((response) => {
+  console.log(response);
 });
 ```
 
@@ -351,11 +352,9 @@ nano.db.replication.enable('alice', 'http://admin:password@otherhost.com:5984/al
 Asks for the changes feed of `name`, `params` contains additions
 to the query string.
 
-``` js
-nano.db.changes('alice', function(err, body) {
-  if (!err) {
-    console.log(body);
-  }
+```js
+nano.db.changes('alice').then((body) => {
+  console.log(body);
 });
 ```
 
@@ -363,13 +362,13 @@ nano.db.changes('alice', function(err, body) {
 
 Uses [Follow] to create a solid changes feed. Please consult `follow` documentation for more information as this is a very complete API on it's own:
 
-``` js
+```js
 var feed = db.follow({since: "now"});
-feed.on('change', function (change) {
+feed.on('change', (change) => {
   console.log("change: ", change);
 });
 feed.follow();
-process.nextTick(function () {
+process.nextTick( () => {
   db.insert({"bar": "baz"}, "bar");
 });
 ```
@@ -379,10 +378,8 @@ process.nextTick(function () {
 Gets database information:
 
 ```js
-nano.db.info(function(err, body) {
-  if (!err) {
-    console.log('got database info', body);
-  }
+nano.db.info().then((body) => {
+  console.log('got database info', body);
 });
 ```
 
@@ -390,9 +387,9 @@ nano.db.info(function(err, body) {
 
 Returns a database object that allows you to perform operations against that database:
 
-``` js
+```js
 var alice = nano.use('alice');
-alice.insert({ happy: true }, 'rabbit', function(err, body) {
+alice.insert({ happy: true }, 'rabbit').then((body) => {
   // do something
 });
 ```
@@ -426,6 +423,7 @@ server, to perform operations where there is no `nano` function that encapsulate
 * `opts.body` – the document or attachment body
 * `opts.encoding` – the encoding for attachments
 * `opts.multipart` – array of objects for multipart request
+* `opts.stream` - if `true`, a `request` object is returned. Default `false` and a Promise is returned.
 
 ### nano.relax(opts, [callback])
 
@@ -459,11 +457,11 @@ Please consult follow documentation for more information as this is a very compl
 
 ```js
 var feed = nano.followUpdates({since: "now"});
-feed.on('change', function (change) {
+feed.on('change', (change) => {
   console.log("change: ", change);
 });
 feed.follow();
-process.nextTick(function () {
+process.nextTick( () => {
   nano.db.create('alice');
 });
 ```
@@ -474,11 +472,10 @@ process.nextTick(function () {
 
 Inserts `doc` in the database with optional `params`. If params is a string, it's assumed it is the intended document `_id`. If params is an object, it's passed as query string parameters and `docName` is checked for defining the document `_id`:
 
-``` js
+```js
 var alice = nano.use('alice');
-alice.insert({ happy: true }, 'rabbit', function(err, body) {
-  if (!err)
-    console.log(body);
+alice.insert({ happy: true }, 'rabbit').then((body) => {
+  console.log(body);
 });
 ```
 
@@ -486,9 +483,8 @@ The `insert` function can also be used with the method signature `db.insert(doc,
 
 ```js
 var alice = nano.use('alice')
-alice.insert({ _id: 'myid', happy: true }, function(err, body) {
-  if (!err)
-    console.log(body)
+alice.insert({ _id: 'myid', happy: true }).then((body) => {
+  console.log(body)
 })
 ```
 
@@ -496,9 +492,8 @@ and also used to update an existing document, by including the `_rev` token in t
 
 ```js
 var alice = nano.use('alice')
-alice.insert({ _id: 'myid', _rev: '1-23202479633c2b380f79507a776743d5', happy: false }, function(err, body) {
-  if (!err)
-    console.log(body)
+alice.insert({ _id: 'myid', _rev: '1-23202479633c2b380f79507a776743d5', happy: false }).then((body) => {
+  console.log(body)
 })
 ```
 
@@ -506,10 +501,9 @@ alice.insert({ _id: 'myid', _rev: '1-23202479633c2b380f79507a776743d5', happy: f
 
 Removes a document from CouchDB whose `_id` is `docname` and who's revision is `_rev`:
 
-``` js
-alice.destroy('rabbit', '3-66c01cdf99e84c83a9b3fe65b88db8c0', function(err, body) {
-  if (!err)
-    console.log(body);
+```js
+alice.destroy('rabbit', '3-66c01cdf99e84c83a9b3fe65b88db8c0').then((body) => {
+  console.log(body);
 });
 ```
 
@@ -517,16 +511,16 @@ alice.destroy('rabbit', '3-66c01cdf99e84c83a9b3fe65b88db8c0', function(err, body
 
 Gets a document from CouchDB whose `_id` is `docname`:
 
-``` js
-alice.get('rabbit', function(err, body) {
+```js
+alice.get('rabbit').then((body) => {
   console.log(body);
 });
 ```
 
 or with optional query string `params`:
 
-``` js
-alice.get('rabbit', { revs_info: true }, function(err, body) {
+```js
+alice.get('rabbit', { revs_info: true }).then((body) => {
   console.log(body);
 });
 ```
@@ -535,22 +529,22 @@ alice.get('rabbit', { revs_info: true }, function(err, body) {
 
 Same as `get` but lightweight version that returns headers only:
 
-``` js
-alice.head('rabbit', function(err, _, headers) {
-  if (!err)
-    console.log(headers);
+```js
+alice.head('rabbit').then((headers) => {
+  console.log(headers);
 });
 ```
+
+*Note:* if you call `alice.head` in the callback style, the headers are returned to you as the third argument of the callback function.
 
 ### db.copy(src_doc, dest_doc, opts, [callback])
 
 Copies the contents (and attachments) of a document
 to a new document, or overwrite an existing target document
 
-``` js
-alice.copy('rabbit', 'rabbit2', { overwrite: true }, function(err, _, headers) {
-  if (!err)
-    console.log(headers);
+```js
+alice.copy('rabbit', 'rabbit2', { overwrite: true }).then((body) => {
+  console.log(body);
 });
 ```
 
@@ -559,12 +553,12 @@ alice.copy('rabbit', 'rabbit2', { overwrite: true }, function(err, _, headers) {
 Bulk operations(update/delete/insert) on the database, refer to the
 [CouchDB doc](http://docs.couchdb.org/en/2.1.1/api/database/bulk-api.html#db-bulk-docs) e.g:
 
-``` js
+```js
 var documents = [
   { a:1, b:2 },
   { _id: 'tiger', striped: true}
 ];
-alice.bulk({docs:documents}, function(err, body) {
+alice.bulk({docs:documents}).then((body) => {
   console.log(body);
 });
 ```
@@ -573,26 +567,22 @@ alice.bulk({docs:documents}, function(err, body) {
 
 List all the docs in the database .
 
-``` js
-alice.list(function(err, body) {
-  if (!err) {
-    body.rows.forEach(function(doc) {
-      console.log(doc);
-    });
-  }
+```js
+alice.list().then((body) => {
+  body.rows.forEach((doc) => {
+    console.log(doc);
+  });
 });
 ```
 
 or with optional query string additions `params`:
 
-``` js
-alice.list({include_docs: true}, function(err, body) {
-  if (!err) {
-    body.rows.forEach(function(doc) {
-      // output eacj document's body
-      console.log(doc.doc);
-    });
-  }
+```js
+alice.list({include_docs: true}).then((body) => {
+  body.rows.forEach((doc) => {
+    // output eacj document's body
+    console.log(doc.doc);
+  });
 });
 ```
 
@@ -605,7 +595,7 @@ to `true`.
 
 ```js
 var keys = ['tiger', 'zebra', 'donkey'];
-alice.fetch({keys: keys}, function(err, data) {
+alice.fetch({keys: keys}).then((data) => {
   console.log(data);
 });
 ```
@@ -629,7 +619,7 @@ var indexDef = {
   index: { fields: ['foo'] },
   name: 'fooindex'
 };
-alice.createIndex(indexDef, function(err, result) {
+alice.createIndex(indexDef).then((result) => {
   console.log(result);
 });
 ```
@@ -641,14 +631,13 @@ alice.createIndex(indexDef, function(err, result) {
 Inserts a `doc` together with `attachments` and `params`. If params is a string, it's assumed as the intended document `_id`. If params is an object, its passed as query string parameters and `docName` is checked for defining the `_id`. Refer to the [doc](http://wiki.apache.org/couchdb/HTTP_Document_API#Multiple_Attachments) for more details.
  The `attachments` parameter must be an array of objects with `name`, `data` and `content_type` properties.
 
-``` js
-var fs = require('fs');
+```js
+const fs = require('fs');
 
-fs.readFile('rabbit.png', function(err, data) {
+fs.readFile('rabbit.png', (err, data) => {
   if (!err) {
-    alice.multipart.insert({ foo: 'bar' }, [{name: 'rabbit.png', data: data, content_type: 'image/png'}], 'mydoc', function(err, body) {
-        if (!err)
-          console.log(body);
+    alice.multipart.insert({ foo: 'bar' }, [{name: 'rabbit.png', data: data, content_type: 'image/png'}], 'mydoc').then((body) => {
+      console.log(body);
     });
   }
 });
@@ -659,10 +648,9 @@ fs.readFile('rabbit.png', function(err, data) {
 Get `docname` together with its attachments via `multipart/related` request with optional query string additions `params`. Refer to the
  [doc](http://wiki.apache.org/couchdb/HTTP_Document_API#Getting_Attachments_With_a_Document) for more details. The multipart response body is a `Buffer`.
 
-``` js
-alice.multipart.get('rabbit', function(err, buffer) {
-  if (!err)
-    console.log(buffer.toString());
+```js
+alice.multipart.get('rabbit').then((buffer) => {
+  console.log(buffer.toString());
 });
 ```
 
@@ -674,28 +662,29 @@ Inserts an attachment `attname` to `docname`, in most cases
  `params.rev` is required. Refer to the
  [CouchDB doc](http://docs.couchdb.org/en/latest/api/document/attachments.html#db-doc-attachment) for more details.
 
-``` js
-var fs = require('fs');
+```js
+const fs = require('fs');
 
-fs.readFile('rabbit.png', function(err, data) {
+fs.readFile('rabbit.png', (err, data) => {
   if (!err) {
     alice.attachment.insert('rabbit', 'rabbit.png', data, 'image/png',
-      { rev: '12-150985a725ec88be471921a54ce91452' }, function(err, body) {
-        if (!err)
-          console.log(body);
+      { rev: '12-150985a725ec88be471921a54ce91452' }).then((body) => {
+        console.log(body);
     });
   }
 });
 ```
 
-or using `pipe`:
+### db.multipart.insertAsStream(doc, attachments, params, [callback])
 
-``` js
-var fs = require('fs');
+It may be more memory-efficient to pipe a stream of data from a source (file, network etc) to a CouchDB attachment:
 
-fs.createReadStream('rabbit.png').pipe(
-    alice.attachment.insert('new', 'rab.png', null, 'image/png')
-);
+```js
+  const rs = fs.createReadStream('logo.png');
+  const is = db.attachment.insertAsStream('mydoc', 'logo.png', null, 'image/png').on('end', () => {
+    console.log('done')
+  });
+  rs.pipe(is);
 ```
 
 ### db.attachment.get(docname, attname, [params], [callback])
@@ -703,22 +692,20 @@ fs.createReadStream('rabbit.png').pipe(
 Get `docname`'s attachment `attname` with optional query string additions
 `params`.
 
-``` js
-var fs = require('fs');
+```js
+const fs = require('fs');
 
-alice.attachment.get('rabbit', 'rabbit.png', function(err, body) {
-  if (!err) {
-    fs.writeFile('rabbit.png', body);
-  }
+alice.attachment.get('rabbit', 'rabbit.png').then((body) => {
+  fs.writeFile('rabbit.png', body);
 });
 ```
 
-or using `pipe`:
+### db.attachment.getAsStream(docname, attname, [params], [callback])
 
-``` js
-var fs = require('fs');
+```js
+const fs = require('fs');
 
-alice.attachment.get('rabbit', 'rabbit.png').pipe(fs.createWriteStream('rabbit.png'));
+alice.attachment.getAsStream('rabbit', 'rabbit.png').pipe(fs.createWriteStream('rabbit.png'));
 ```
 
 ### db.attachment.destroy(docname, attname, [params], [callback])
@@ -727,11 +714,10 @@ alice.attachment.get('rabbit', 'rabbit.png').pipe(fs.createWriteStream('rabbit.p
 
 Destroy attachment `attname` of `docname`'s revision `rev`.
 
-``` js
+```js
 alice.attachment.destroy('rabbit', 'rabbit.png',
-    {rev: '1-4701d73a08ce5c2f2983bf7c9ffd3320'}, function(err, body) {
-      if (!err)
-        console.log(body);
+    {rev: '1-4701d73a08ce5c2f2983bf7c9ffd3320'}).then((body) => {
+       console.log(body);
 });
 ```
 
@@ -742,52 +728,44 @@ alice.attachment.destroy('rabbit', 'rabbit.png',
 Calls a view of the specified `designname` with optional query string `params`. If you're looking to filter the view results by key(s) pass an array of keys, e.g
 `{ keys: ['key1', 'key2', 'key_n'] }`, as `params`.
 
-``` js
+```js
 alice.view('characters', 'happy_ones', {
   'key': 'Tea Party',
   'include_docs': true
-}, function(err, body) {
-  if (!err) {
-    body.rows.forEach(function(doc) {
-      console.log(doc.value);
-    });
-  }
+}).then((body) => {
+  body.rows.forEach((doc) => {
+    console.log(doc.value);
+  });
 });
 ```
 
 or
 
-``` js
+```js
 alice.view('characters', 'soldiers', {
   'keys': ['Hearts', 'Clubs']
-}, function(err, body) {
-  if (!err) {
-    body.rows.forEach(function(doc) {
-      console.log(doc.value);
-    });
-  }
+}).then((body) => {
+  body.rows.forEach((doc) => {
+    console.log(doc.value);
+  });
 });
 ```
 
 When `params` is not supplied, or no keys are specified, it will simply return all documents in the view:
 
-``` js
-alice.view('characters', 'happy_ones', function(err, body) {
-  if (!err) {
-    body.rows.forEach(function(doc) {
-      console.log(doc.value);
-    });
-  }
+```js
+alice.view('characters', 'happy_ones').then((body) => {
+  body.rows.forEach((doc) => {
+    console.log(doc.value);
+  });
 });
 ```
 
-``` js
-alice.view('characters', 'happy_ones', { include_docs: true }, function(err, body) {
-  if (!err) {
-    body.rows.forEach(function(doc) {
-      console.log(doc.value);
-    });
-  }
+```js
+alice.view('characters', 'happy_ones', { include_docs: true }).then((body) => {
+  body.rows.forEach((doc) => {
+    console.log(doc.value);
+  });
 });
 ```
 
@@ -795,11 +773,9 @@ alice.view('characters', 'happy_ones', { include_docs: true }, function(err, bod
 
 Calls a list function fed by the given view from the specified design document.
 
-``` js
-alice.viewWithList('characters', 'happy_ones', 'my_list', function(err, body) {
-  if (!err) {
-    console.log(body);
-  }
+```js
+alice.viewWithList('characters', 'happy_ones', 'my_list').then((body) => {
+  console.log(body);
 });
 ```
 
@@ -808,11 +784,9 @@ alice.viewWithList('characters', 'happy_ones', 'my_list', function(err, body) {
 Calls a show function from the specified design for the document specified by doc_id with
 optional query string additions `params`.
 
-``` js
-alice.show('characters', 'format_doc', '3621898430', function(err, doc) {
-  if (!err) {
-    console.log(doc);
-  }
+```js
+alice.show('characters', 'format_doc', '3621898430').then((doc) => {
+  console.log(doc);
 });
 ```
 
@@ -823,18 +797,17 @@ for possible query paramaters and more information on show functions.
 
 Calls the design's update function with the specified doc in input.
 
-``` js
+```js
 db.atomic("update", "inplace", "foobar",
-{field: "foo", value: "bar"}, function (error, response) {
-  assert.equal(error, undefined, "failed to update");
-  assert.equal(response.foo, "bar", "update worked");
+{field: "foo", value: "bar"}).then((response) => {
+  console.log(response);
 });
 ```
 
 Note that the data is sent in the body of the request.
 An example update handler follows:
 
-``` js
+```js
 "updates": {
   "in-place" : "function(doc, req) {
       var field = req.form.field;
@@ -843,17 +816,16 @@ An example update handler follows:
       doc[field] = value;
       return [doc, message];
   }"
+}
 ```
 
 ### db.search(designname, searchname, [params], [callback])
 
 Calls a view of the specified design with optional query string additions `params`.
 
-``` js
-alice.search('characters', 'happy_ones', { q: 'cat' }, function(err, doc) {
-  if (!err) {
-    console.log(doc);
-  }
+```js
+alice.search('characters', 'happy_ones', { q: 'cat' }).then((doc) => {
+  console.log(doc);
 });
 ```
 
@@ -861,63 +833,29 @@ Check out the tests for a fully functioning example.
 
 ## using cookie authentication
 
-Nano supports making requests using CouchDB's [cookie authentication](http://guide.couchdb.org/editions/1/en/security.html#cookies) functionality. There's an [example in coffeescript](http://stackoverflow.com/questions/23100132/using-nano-auth-correctly), but essentially you just:
+Nano supports making requests using CouchDB's [cookie authentication](http://guide.couchdb.org/editions/1/en/security.html#cookies) functionality. Call `nano.auth` first to get a session cookie. As we initialise `nano` with `requestDefaults: { jar: true }`, we are asking the `request` library to behave like a web browser - remembering any cookies that the server sets and sending them back in subsequent requests:
 
-``` js
-var nano     = require('nano')('http://localhost:5984'),
+```js
+const nano = require('nano')({ url: 'http://localhost:5984', requestDefaults: { jar: true }}),
   username = 'user',
   userpass = 'pass',
-  callback = console.log, // this would normally be some callback
-  cookies  = {}; // store cookies, normally redis or something
+  db = nano.db.use('mydb');
 
-
-nano.auth(username, userpass, function (err, body, headers) {
-  if (err) {
-    return callback(err);
-  }
-
-  if (headers && headers['set-cookie']) {
-    cookies[user] = headers['set-cookie'];
-  }
-
-  callback(null, "it worked");
+nano.auth(username, userpass).then((() => {
+  return db.get('mydoc');
+}).then((doc) => {
+  console.log(doc);
 });
 ```
 
-Reusing a cookie:
+The second request works because the `nano` library has remembered the `AuthSession` cookie that was invisibily returned by the `nano.auth` call. 
 
-``` js
-var auth = "some stored cookie",
-  callback = console.log, // this would normally be some callback
-  alice = require('nano')(
-    { url : 'http://localhost:5984/alice', cookie: 'AuthSession=' + auth });
+When you have a session, you can see what permissions you have by calling the `nano.session` function
 
-alice.insert(doc, function (err, body, headers) {
-  if (err) {
-    return callback(err);
-  }
-
-  // change the cookie if CouchDB tells us to
-  if (headers && headers['set-cookie']) {
-    auth = headers['set-cookie'];
-  }
-
-  callback(null, "it worked");
-});
-```
-
-Getting current session:
-
-```javascript
-var nano = require('nano')({url: 'http://localhost:5984', cookie: 'AuthSession=' + auth});
-
-nano.session(function(err, session) {
-  if (err) {
-    return console.log('oh noes!')
-  }
-
-  console.log('user is %s and has these roles: %j',
-    session.userCtx.name, session.userCtx.roles);
+```js
+nano.session().then((doc) => {
+  console.log(doc)
+  // { userCtx: { roles: [ '_admin', '_reader', '_writer' ], name: 'rita' },  ok: true }
 });
 ```
 
@@ -928,7 +866,9 @@ nano.session(function(err, session) {
 If your application needs to generate UUIDs, then CouchDB can provide some for you
 
 ```js
-nano.uuids(3, callback);
+nano.uuids(3).then((doc) => {
+  console.log(doc);
+});
 // { uuids: [
 // '5d1b3ef2bc7eea51f660c091e3dffa23',
 // '5d1b3ef2bc7eea51f660c091e3e006ff',
@@ -941,39 +881,44 @@ The first parameter is the number of uuids to generate. If omitted, it defaults 
 ### Extending nano
 
 `nano` is minimalistic but you can add your own features with
-`nano.request(opts, callback)`
+`nano.request(opts)`
 
 For example, to create a function to retrieve a specific revision of the
 `rabbit` document:
 
-``` js
-function getrabbitrev(rev, callback) {
-  nano.request({ db: 'alice',
+```js
+function getrabbitrev(rev) {
+  return nano.request({ db: 'alice',
                  doc: 'rabbit',
                  method: 'get',
                  params: { rev: rev }
-               }, callback);
+               });
 }
 
-getrabbitrev('4-2e6cdc4c7e26b745c2881a24e0eeece2', function(err, body) {
-  if (!err) {
-    console.log(body);
-  }
+getrabbitrev('4-2e6cdc4c7e26b745c2881a24e0eeece2').then((body) => {
+  console.log(body);
 });
 ```
 
 ### Pipes
 
-You can pipe in nano like in any other stream. For example if our `rabbit` document has an attachment with name `picture.png` you can pipe it to a `writable stream`:
+You can pipe the return values of certain nano functions like other stream. For example if our `rabbit` document has an attachment with name `picture.png` you can pipe it to a `writable stream`:
 
-``` js
+```js
 var fs = require('fs'),
     nano = require('nano')('http://127.0.0.1:5984/');
 var alice = nano.use('alice');
-alice.attachment.get('rabbit', 'picture.png').pipe(fs.createWriteStream('/tmp/rabbit.png'));
+alice.attachment.getAsStream('rabbit', 'picture.png').pipe(fs.createWriteStream('/tmp/rabbit.png'));
 ```
 
 then open `/tmp/rabbit.png` and you will see the rabbit picture.
+
+Functions that return streams instead of a Promise are:
+
+- db.insertAsStream
+- db.listAsStream
+- db.attachment.getAsStream
+- db.attachment.insertAsStream
 
 ## Tutorials, examples in the wild & screencasts
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Note the minimum required version of Node.js is 6.
   - [nano.db.get(name, [callback])](#nanodbgetname-callback)
   - [nano.db.destroy(name, [callback])](#nanodbdestroyname-callback)
   - [nano.db.list([callback])](#nanodblistcallback)
+  - [nano.db.listAsStream([callback])](#nanodblistasstreamcallback)
   - [nano.db.compact(name, [designname], [callback])](#nanodbcompactname-designname-callback)
   - [nano.db.replicate(source, target, [opts], [callback])](#nanodbreplicatesource-target-opts-callback)
   - [nano.db.replication.enable(source, target, [opts], [callback])](#nanodbreplicationenablesource-target-opts-callback)
@@ -54,6 +55,7 @@ Note the minimum required version of Node.js is 6.
   - [db.copy(src_doc, dest_doc, opts, [callback])](#dbcopysrc_doc-dest_doc-opts-callback)
   - [db.bulk(docs, [params], [callback])](#dbbulkdocs-params-callback)
   - [db.list([params], [callback])](#dblistparams-callback)
+  - [db.listAsStream([params], [callback])](#dblistasstreamparams-callback)
   - [db.fetch(docnames, [params], [callback])](#dbfetchdocnames-params-callback)
   - [db.fetchRevs(docnames, [params], [callback])](#dbfetchrevsdocnames-params-callback)
   - [db.createIndex(indexDef, [callback])](#dbcreateindexindexdef-callback)
@@ -287,6 +289,14 @@ nano.db.list().then((body) => {
     console.log(db);
   });
 });
+```
+
+### nano.db.listAsStream([callback])
+
+Lists all the CouchDB databases as a stream:
+
+```js
+nano.db.list().pipe(process.stdout);
 ```
 
 ### nano.db.compact(name, [designname], [callback])
@@ -584,6 +594,14 @@ alice.list({include_docs: true}).then((body) => {
     console.log(doc.doc);
   });
 });
+```
+
+### db.listAsStream([params], [callback])
+
+List all the docs in the database as a stream.
+
+```js
+alice.list().pipe(process.stdout)
 ```
 
 ### db.fetch(docnames, [params], [callback])
@@ -915,10 +933,16 @@ then open `/tmp/rabbit.png` and you will see the rabbit picture.
 
 Functions that return streams instead of a Promise are:
 
-- db.insertAsStream
-- db.listAsStream
+- nano.db.listAsStream
+
+attachment functions:
+
 - db.attachment.getAsStream
 - db.attachment.insertAsStream
+
+and document level functions
+
+- db.listAsStream
 
 ## Tutorials, examples in the wild & screencasts
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -12,14 +12,14 @@
 
 'use strict';
 
-var debug = require('debug')('nano/logger');
+const debug = require('debug')('nano/logger');
 
 module.exports = function logging(cfg) {
-  var log = cfg && cfg.log;
-  var logStrategy = typeof log === 'function' ? log : debug;
+  const log = cfg && cfg.log;
+  const logStrategy = typeof log === 'function' ? log : debug;
 
   return function logEvent(prefix) {
-    var eventId = (prefix ? prefix + '-' : '') +
+    const eventId = (prefix ? prefix + '-' : '') +
       (~~(Math.random() * 1e9)).toString(36);
     return function log() {
       logStrategy.call(this, eventId, [].slice.call(arguments, 0));

--- a/lib/nano.d.ts
+++ b/lib/nano.d.ts
@@ -13,7 +13,7 @@ import { CoreOptions, Request } from "request";
 
 declare function nano(
   config: nano.Configuration | string
-): nano.ServerScope | nano.DocumentScope<any>;
+): nano.ServerScope;
 
 declare namespace nano {
   interface Configuration {
@@ -32,137 +32,141 @@ declare namespace nano {
     db: DatabaseScope;
     use<D>(db: string): DocumentScope<D>;
     scope<D>(db: string): DocumentScope<D>;
-    request: RequestFunction;
-    relax: RequestFunction;
-    dinosaur: RequestFunction;
+    request: Promise<any>;
+    relax: Promise<any>;
+    dinosaur: Promise<any>;
     // http://docs.couchdb.org/en/latest/api/server/authn.html#cookie-authentication
-    auth(username: string, userpass: string, callback?: Callback<DatabaseAuthResponse>): Request;
+    auth(username: string, userpass: string, callback?: Callback<DatabaseAuthResponse>): Promise<DatabaseAuthResponse>;
     // http://docs.couchdb.org/en/latest/api/server/authn.html#get--_session
-    session(callback?: Callback<DatabaseSessionResponse>): Request;
+    session(callback?: Callback<DatabaseSessionResponse>): Promise<DatabaseSessionResponse>;
     // http://docs.couchdb.org/en/latest/api/server/common.html#get--_db_updates
-    updates(callback?: Callback<DatabaseUpdatesResponse>): Request;
+    updates(callback?: Callback<DatabaseUpdatesResponse>): Promise<DatabaseUpdatesResponse>;
     // http://docs.couchdb.org/en/latest/api/server/common.html#get--_db_updates
-    updates(params: UpdatesParams, callback?: Callback<DatabaseUpdatesResponse>): Request;
+    updates(params: UpdatesParams, callback?: Callback<DatabaseUpdatesResponse>): Promise<DatabaseUpdatesResponse>;
     followUpdates(callback?: Callback<any>): EventEmitter;
     followUpdates(params: any, callback?: Callback<any>): EventEmitter;
-    uuids(num: number, callback: Callback<any>): Request;
+    uuids(num: number, callback?: Callback<any>): Promise<UUIDObject>;
+  }
+
+  interface UUIDObject {
+    uuids: string[]
   }
 
   interface DatabaseScope {
     // http://docs.couchdb.org/en/latest/api/database/common.html#put--db
-    create(name: string, callback?: Callback<DatabaseCreateResponse>): Request;
+    create(name: string, callback?: Callback<DatabaseCreateResponse>): Promise<DatabaseCreateResponse>;
     // http://docs.couchdb.org/en/latest/api/database/common.html#get--db
-    get(name: string, callback?: Callback<DatabaseGetResponse>): Request;
+    get(name: string, callback?: Callback<DatabaseGetResponse>): Promise<DatabaseGetResponse>;
     // http://docs.couchdb.org/en/latest/api/database/common.html#delete--db
-    destroy(name: string, callback?: Callback<OkResponse>): Request;
+    destroy(name: string, callback?: Callback<OkResponse>): Promise<OkResponse>;
     // http://docs.couchdb.org/en/latest/api/server/common.html#get--_all_dbs
-    list(callback?: Callback<string[]>): Request;
+    list(callback?: Callback<string[]>): Promise<string[]>;
     use<D>(db: string): DocumentScope<D>;
-    compact(name: string, callback?: Callback<OkResponse>): Request;
+    compact(name: string, callback?: Callback<OkResponse>): Promise<OkResponse>;
     // http://docs.couchdb.org/en/latest/api/database/compact.html#post--db-_compact
-    compact(name: string, designname: string, callback?: Callback<OkResponse>): Request;
+    compact(name: string, designname: string, callback?: Callback<OkResponse>): Promise<OkResponse>;
     // http://docs.couchdb.org/en/latest/api/server/common.html#post--_replicate
     replicate<D>(
       source: string | DocumentScope<D>,
       target: string | DocumentScope<D>,
       callback?: Callback<DatabaseReplicateResponse>
-    ): Request;
+    ): Promise<DatabaseReplicateResponse>;
     // http://docs.couchdb.org/en/latest/api/server/common.html#post--_replicate
     replicate<D>(
       source: string | DocumentScope<D>,
       target: string | DocumentScope<D>,
       options: DatabaseReplicateOptions,
       callback?: Callback<DatabaseReplicateResponse>
-    ): Request;
+    ): Promise<DatabaseReplicateResponse>;
     // http://docs.couchdb.org/en/latest/api/database/changes.html#get--db-_changes
-    changes(name: string, callback?: Callback<DatabaseChangesResponse>): Request;
+    changes(name: string, callback?: Callback<DatabaseChangesResponse>): Promise<DatabaseChangesResponse>;
     // http://docs.couchdb.org/en/latest/api/database/compact.html#post--db-_compact
-    changes(name: string, params: DatabaseChangesParams, callback?: Callback<DatabaseChangesResponse>): Request;
+    changes(name: string, params: DatabaseChangesParams, callback?: Callback<DatabaseChangesResponse>): Promise<DatabaseChangesResponse>;
     follow(source: string, callback?: Callback<any>): EventEmitter;
     follow(source: string, params: DatabaseScopeFollowUpdatesParams, callback?: Callback<any>): EventEmitter;
     followUpdates(params?: any, callback?: Callback<any>): EventEmitter;
     // http://docs.couchdb.org/en/latest/api/server/common.html#get--_db_updates
-    updates(callback?: Callback<DatabaseUpdatesResponse>): Request;
+    updates(callback?: Callback<DatabaseUpdatesResponse>): Promise<DatabaseUpdatesResponse>;
     // http://docs.couchdb.org/en/latest/api/server/common.html#get--_db_updates
-    updates(params: UpdatesParams, callback?: Callback<DatabaseUpdatesResponse>): Request;
+    updates(params: UpdatesParams, callback?: Callback<DatabaseUpdatesResponse>): Promise<DatabaseUpdatesResponse>;
   }
 
   interface DocumentScope<D> {
     readonly config: ServerConfig;
     // http://docs.couchdb.org/en/latest/api/database/common.html#get--db
-    info(callback?: Callback<DatabaseGetResponse>): Request;
+    info(callback?: Callback<DatabaseGetResponse>): Promise<DatabaseGetResponse>;
     // http://docs.couchdb.org/en/latest/api/server/common.html#post--_replicate
     replicate<D>(
       target: string | DocumentScope<D>,
       callback?: Callback<DatabaseReplicateResponse>
-    ): Request;
+    ): Promise<DatabaseReplicateResponse>;
     // http://docs.couchdb.org/en/latest/api/server/common.html#post--_replicate
     replicate(
       target: string | DocumentScope<D>,
       options: any,
       callback?: Callback<DatabaseReplicateResponse>
-    ): Request;
+    ): Promise<DatabaseReplicateResponse>;
     // http://docs.couchdb.org/en/latest/api/database/compact.html#post--db-_compact
-    compact(callback?: Callback<any>): Request;
+    compact(callback?: Callback<OkResponse>): Promise<OkResponse>;
     // http://docs.couchdb.org/en/latest/api/database/changes.html#get--db-_changes
-    changes(callback?: Callback<DatabaseChangesResponse>): Request;
+    changes(callback?: Callback<DatabaseChangesResponse>): Promise<DatabaseChangesResponse>;
     // http://docs.couchdb.org/en/latest/api/database/changes.html#get--db-_changes
-    changes(params: DatabaseChangesParams, callback?: Callback<DatabaseChangesResponse>): Request;
+    changes(params: DatabaseChangesParams, callback?: Callback<DatabaseChangesResponse>): Promise<DatabaseChangesResponse>;
     follow(callback?: Callback<any>): EventEmitter;
     follow(params: DocumentScopeFollowUpdatesParams, callback?: Callback<any>): EventEmitter;
     // http://docs.couchdb.org/en/latest/api/server/authn.html#cookie-authentication
-    auth(username: string, userpass: string, callback?: Callback<DatabaseAuthResponse>): Request;
+    auth(username: string, userpass: string, callback?: Callback<DatabaseAuthResponse>): Promise<DatabaseAuthResponse>;
     // http://docs.couchdb.org/en/latest/api/server/authn.html#get--_session
-    session(callback?: Callback<any>): Request;
+    session(callback?: Callback<DatabaseSessionResponse>): Promise<DatabaseSessionResponse>;
     // http://docs.couchdb.org/en/latest/api/database/common.html#post--db
     // http://docs.couchdb.org/en/latest/api/document/common.html#put--db-docid
-    insert(document: ViewDocument<D> | D & MaybeDocument, callback?: Callback<DocumentInsertResponse>): Request;
+    insert(document: ViewDocument<D> | D & MaybeDocument, callback?: Callback<DocumentInsertResponse>): Promise<DocumentInsertResponse>;
     // http://docs.couchdb.org/en/latest/api/database/common.html#post--db
     // http://docs.couchdb.org/en/latest/api/document/common.html#put--db-docid
     insert(
       document: ViewDocument<D> | D & MaybeDocument,
       params: DocumentInsertParams | string | null,
       callback?: Callback<DocumentInsertResponse>
-    ): Request;
+    ): Promise<DocumentInsertResponse>;
     // http://docs.couchdb.org/en/latest/api/document/common.html#get--db-docid
-    get(docname: string, callback?: Callback<DocumentGetResponse & D>): Request;
+    get(docname: string, callback?: Callback<DocumentGetResponse & D>): Promise<DocumentGetResponse>;
     // http://docs.couchdb.org/en/latest/api/document/common.html#get--db-docid
-    get(docname: string, params?: DocumentGetParams, callback?: Callback<DocumentGetResponse & D>): Request;
+    get(docname: string, params?: DocumentGetParams, callback?: Callback<DocumentGetResponse & D>): Promise<DocumentGetResponse>;
     // http://docs.couchdb.org/en/latest/api/document/common.html#head--db-docid
-    head(docname: string, callback: Callback<any>): Request;
+    head(docname: string, callback?: Callback<object>): Promise<object>;
     // http://docs.couchdb.org/en/latest/api/document/common.html#copy--db-docid
-    copy(src_document: string, dst_document: string, callback?: Callback<DocumentCopyResponse>): Request;
+    copy(src_document: string, dst_document: string, callback?: Callback<DocumentCopyResponse>): Promise<DocumentCopyResponse>;
     // http://docs.couchdb.org/en/latest/api/document/common.html#copy--db-docid
     copy(
       src_document: string,
       dst_document: string,
       options: DocumentCopyOptions,
       callback?: Callback<DocumentCopyResponse>
-    ): Request;
+    ): Promise<DocumentCopyResponse>;
     // http://docs.couchdb.org/en/latest/api/document/common.html#delete--db-docid
-    destroy(docname: string, rev: string, callback?: Callback<DocumentDestroyResponse>): Request;
-    bulk(docs: BulkModifyDocsWrapper, callback?: Callback<any>): Request;
-    bulk(docs: BulkModifyDocsWrapper, params: any, callback?: Callback<any>): Request;
+    destroy(docname: string, rev: string, callback?: Callback<DocumentDestroyResponse>): Promise<DocumentDestroyResponse>;
+    bulk(docs: BulkModifyDocsWrapper, callback?: Callback<DocumentInsertResponse[]>): Promise<DocumentInsertResponse[]>;
+    bulk(docs: BulkModifyDocsWrapper, params: any, callback?: Callback<DocumentInsertResponse[]>): Promise<DocumentInsertResponse[]>;
     // http://docs.couchdb.org/en/latest/api/database/bulk-api.html#get--db-_all_docs
-    list(callback?: Callback<DocumentListResponse<D>>): Request;
+    list(callback?: Callback<DocumentListResponse<D>>): Promise<DocumentListResponse<D>>;
     // http://docs.couchdb.org/en/latest/api/database/bulk-api.html#get--db-_all_docs
-    list(params: DocumentListParams, callback?: Callback<DocumentListResponse<D>>): Request;
+    list(params: DocumentListParams, callback?: Callback<DocumentListResponse<D>>): Promise<DocumentListResponse<D>>;
     // http://docs.couchdb.org/en/latest/api/database/bulk-api.html#post--db-_all_docs
-    fetch(docnames: BulkFetchDocsWrapper, callback?: Callback<DocumentFetchResponse<D>>): Request;
+    fetch(docnames: BulkFetchDocsWrapper, callback?: Callback<DocumentFetchResponse<D>>): Promise<DocumentFetchResponse<D>>;
     // http://docs.couchdb.org/en/latest/api/database/bulk-api.html#post--db-_all_docs
     fetch(
       docnames: BulkFetchDocsWrapper,
       params: DocumentFetchParams,
       callback?: Callback<DocumentFetchResponse<D>>
-    ): Request;
+    ): Promise<DocumentFetchResponse<D>>;
     // http://docs.couchdb.org/en/latest/api/database/bulk-api.html#post--db-_all_docs
-    fetchRevs(docnames: BulkFetchDocsWrapper, callback?: Callback<DocumentFetchRevsResponse>): Request;
+    fetchRevs(docnames: BulkFetchDocsWrapper, callback?: Callback<DocumentFetchRevsResponse>): Promise<DocumentFetchRevsResponse>;
     // http://docs.couchdb.org/en/latest/api/database/bulk-api.html#post--db-_all_docs
     fetchRevs(
       docnames: BulkFetchDocsWrapper,
       params: DocumentFetchParams,
       callback?: Callback<DocumentFetchRevsResponse>
-    ): Request;
+    ): Promise<DocumentFetchRevsResponse>;
     multipart: Multipart<D>;
     attachment: Attachment;
     // http://docs.couchdb.org/en/latest/api/ddoc/render.html#get--db-_design-ddoc-_show-func
@@ -171,7 +175,7 @@ declare namespace nano {
       showname: string,
       doc_id: string,
       callback?: Callback<any>
-    ): Request;
+    ): Promise<any>;
     // http://docs.couchdb.org/en/latest/api/ddoc/render.html#get--db-_design-ddoc-_show-func
     show(
       designname: string,
@@ -179,14 +183,14 @@ declare namespace nano {
       doc_id: string,
       params: any,
       callback?: Callback<any>
-    ): Request;
+    ): Promise<any>;
     // http://docs.couchdb.org/en/latest/api/ddoc/render.html#put--db-_design-ddoc-_update-func-docid
     atomic(
       designname: string,
       updatename: string,
       docname: string,
       callback?: Callback<OkResponse>
-    ): Request;
+    ): Promise<OkResponse>;
     // http://docs.couchdb.org/en/latest/api/ddoc/render.html#put--db-_design-ddoc-_update-func-docid
     atomic(
       designname: string,
@@ -194,14 +198,14 @@ declare namespace nano {
       docname: string,
       body: any,
       callback?: Callback<OkResponse>
-    ): Request;
+    ): Promise<OkResponse>;
     // http://docs.couchdb.org/en/latest/api/ddoc/render.html#put--db-_design-ddoc-_update-func-docid
     updateWithHandler(
       designname: string,
       updatename: string,
       docname: string,
       callback?: Callback<OkResponse>
-    ): Request;
+    ): Promise<OkResponse>;
     // http://docs.couchdb.org/en/latest/api/ddoc/render.html#put--db-_design-ddoc-_update-func-docid
     updateWithHandler(
       designname: string,
@@ -209,36 +213,36 @@ declare namespace nano {
       docname: string,
       body: any,
       callback?: Callback<OkResponse>
-    ): Request;
-    search(
+    ): Promise<OkResponse>;
+    search<V>(
       designname: string,
       searchname: string,
-      callback?: Callback<any>
-    ): Request;
-    search(
+      callback?: Callback<DocumentSearchResponse<V>>
+    ): Promise<DocumentSearchResponse<V>>;
+    search<V>(
       designname: string,
       searchname: string,
-      params: any,
-      callback?: Callback<any>
-    ): Request;
+      params: DocumentSearchParams,
+      callback?: Callback<DocumentSearchResponse<V>>
+    ): Promise<DocumentSearchResponse<V>>;
     spatial(
       ddoc: string,
       viewname: string,
       callback?: Callback<any>
-    ): Request;
+    ): Promise<any>;
     spatial(
       ddoc: string,
       viewname: string,
       params: any,
       callback?: Callback<any>
-    ): Request;
+    ): Promise<any>;
     // http://docs.couchdb.org/en/latest/api/ddoc/views.html#get--db-_design-ddoc-_view-view
     // http://docs.couchdb.org/en/latest/api/ddoc/views.html#post--db-_design-ddoc-_view-view
     view<V>(
       designname: string,
       viewname: string,
       callback?: Callback<DocumentViewResponse<V>>
-    ): Request;
+    ): DocumentViewResponse<V>;
     // http://docs.couchdb.org/en/latest/api/ddoc/views.html#get--db-_design-ddoc-_view-view
     // http://docs.couchdb.org/en/latest/api/ddoc/views.html#post--db-_design-ddoc-_view-view
     view<V>(
@@ -253,7 +257,7 @@ declare namespace nano {
       viewname: string,
       listname: string,
       callback?: Callback<any>
-    ): Request;
+    ): Promise<any>;
     // http://docs.couchdb.org/en/latest/api/ddoc/render.html#db-design-design-doc-list-list-name-view-name
     viewWithList(
       designname: string,
@@ -261,9 +265,9 @@ declare namespace nano {
       listname: string,
       params: DocumentViewParams,
       callback?: Callback<any>
-    ): Request;
+    ): Promise<any>;
     // http://docs.couchdb.org/en/latest/api/database/find.html#db-find
-    find(query: MangoQuery, callback?: Callback<MangoResponse<D>>): Request;
+    find(query: MangoQuery, callback?: Callback<MangoResponse<D>>): Promise <MangoResponse<D>>;
     server: ServerScope;
   }
 
@@ -275,22 +279,23 @@ declare namespace nano {
 
   interface Multipart<D> {
     // http://docs.couchdb.org/en/latest/api/document/common.html#creating-multiple-attachments
-    insert(doc: D, attachments: AttachmentData[], callback?: Callback<DocumentInsertResponse>): Request;
+    insert(doc: D, attachments: AttachmentData[], callback?: Callback<DocumentInsertResponse>): Promise<DocumentInsertResponse>;
     // http://docs.couchdb.org/en/latest/api/document/common.html#creating-multiple-attachments
-    insert(doc: D, attachments: AttachmentData[], params: any, callback?: Callback<DocumentInsertResponse>): Request;
-    get(docname: string, callback?: Callback<any>): Request;
-    get(docname: string, params: any, callback?: Callback<any>): Request;
+    insert(doc: D, attachments: AttachmentData[], params: any, callback?: Callback<DocumentInsertResponse>): Promise<DocumentInsertResponse>;
+    get(docname: string, callback?: Callback<any>): Promise<any>;
+    get(docname: string, params: any, callback?: Callback<any>): Promise<any>;
   }
 
   interface Attachment {
-    insert(docname: string, attname: string, att: null, contenttype: string, params?: any): NodeJS.WritableStream;
+    // NodeJS.WritableStream
+    insert(docname: string, attname: string, att: null, contenttype: string, params?: any): Promise<DocumentInsertResponse>;
     insert(
       docname: string,
       attname: string,
       att: any,
       contenttype: string,
       callback?: Callback<DocumentInsertResponse>
-    ): Request;
+    ): Promise<DocumentInsertResponse>;
     insert(
       docname: string,
       attname: string,
@@ -298,22 +303,22 @@ declare namespace nano {
       contenttype: string,
       params: any,
       callback?: Callback<DocumentInsertResponse>
-    ): Request;
+    ): Promise<DocumentInsertResponse>;
     get(docname: string, attname: string): NodeJS.ReadableStream;
-    get(docname: string, attname: string, callback?: Callback<any>): Request;
+    get(docname: string, attname: string, callback?: Callback<any>): Promise<any>;
     get(
       docname: string,
       attname: string,
       params: any,
       callback?: Callback<any>
-    ): Request;
-    destroy(docname: string, attname: string, callback?: Callback<any>): Request;
+    ): Promise<any>;
+    destroy(docname: string, attname: string, callback?: Callback<any>): Promise<any>;
     destroy(
       docname: string,
       attname: string,
       params: any,
       callback?: Callback<any>
-    ): Request;
+    ): Promise<any>;
   }
 
   interface ServerConfig {
@@ -944,6 +949,94 @@ declare namespace nano {
     rows: DocumentResponseRowMeta[];
     total_rows: number;
     update_seq?: number;
+  }
+
+
+  interface DocumentSearchResponse<V> {
+
+    //  Array of search results
+    rows: Array<{
+      id: string;
+      order: number[];
+      fields: object;
+      key: string;
+      doc?: V;
+    }>;
+
+    // Number of documents in the search resykts
+    total_rows: number;
+
+    // token which if supplied to a subsequent search will return the next page of results.
+    bookmark: string;
+
+    // facet counts
+    counts?: object;
+
+    // facet range results
+    ranges?: object;
+
+    highlights?: object;
+
+  }
+
+  // https://console.bluemix.net/docs/services/Cloudant/api/search.html#queries
+  interface DocumentSearchParams {
+    // A bookmark that was received from a previous search. Used for pagination.
+    bookmark?: string;
+
+    // An array of field names for which facet counts are requested. 
+    counts?: string[];
+
+    // Filters the result set using key value pairs supplied to the drilldown parameter.
+    drilldown?: string[];
+
+    // The name of a string field to group results by.
+    group_field?: string;
+
+    // The maximum group count when used in conjunction with group_field.
+    group_limit?: number;
+
+    // Defines the order of the groups in a search when used with group_field. 
+    group_sort?: string | string[];
+
+    // Which fields are to be highlighted.
+    highlight_fields?: string[];
+
+    // String used before a highlighted word. Defaults to <em>.
+    highlight_pre_tag?: string;
+
+    // String used after a highlighted word. Defaults to </em>.
+    highlight_post_tag?: string;
+
+    // The number of gradments that are returned in highlights. Defaults to 1.
+    highlight_number?: number;
+    
+    // The number of characters in each fragment for highlight. Defaults to 100.
+    highlight_size?: number;
+
+    // Include the full document bodies in the response. Defaults to false
+    include_docs?: boolean;
+
+    // An array of fields to include in the search results.
+    include_fields?: string[];
+
+    // The maximum number of returned documents. Positive integer up to 200.
+    limit?: number;
+
+    // Alias of 'query'. One of q or query must be present.
+    q?: string;
+
+    // The Lucene query to perform. One of q or query must be present.
+    query?: string;
+
+    // Defines ranges for faceted numeric search fields.
+    ranges?: object;
+
+    // Specifies the sort order of the results. 
+    sort?: string | string[];
+
+    // Do not wait for the index to finish building to return results.
+    stale?: boolean
   }
 
   // http://docs.couchdb.org/en/latest/api/ddoc/views.html#get--db-_design-ddoc-_view-view

--- a/lib/nano.d.ts
+++ b/lib/nano.d.ts
@@ -248,7 +248,7 @@ declare namespace nano {
       designname: string,
       viewname: string,
       callback?: Callback<DocumentViewResponse<V>>
-    ): DocumentViewResponse<V>;
+    ): Promise<DocumentViewResponse<V>>; 
     // http://docs.couchdb.org/en/latest/api/ddoc/views.html#get--db-_design-ddoc-_view-view
     // http://docs.couchdb.org/en/latest/api/ddoc/views.html#post--db-_design-ddoc-_view-view
     view<V>(
@@ -256,7 +256,22 @@ declare namespace nano {
       viewname: string,
       params: DocumentViewParams,
       callback?: Callback<DocumentViewResponse<V>>
-    ): Request;
+    ): Promise<DocumentViewResponse<V>>;
+    // http://docs.couchdb.org/en/latest/api/ddoc/views.html#get--db-_design-ddoc-_view-view
+    // http://docs.couchdb.org/en/latest/api/ddoc/views.html#post--db-_design-ddoc-_view-view
+    viewAsStream<V>(
+      designname: string,
+      viewname: string,
+      callback?: Callback<DocumentViewResponse<V>>
+    ): Request; 
+    // http://docs.couchdb.org/en/latest/api/ddoc/views.html#get--db-_design-ddoc-_view-view
+    // http://docs.couchdb.org/en/latest/api/ddoc/views.html#post--db-_design-ddoc-_view-view
+    viewAsStream<V>(
+      designname: string,
+      viewname: string,
+      params: DocumentViewParams,
+      callback?: Callback<DocumentViewResponse<V>>
+    ): Request;    
     // http://docs.couchdb.org/en/latest/api/ddoc/render.html#db-design-design-doc-list-list-name-view-name
     viewWithList(
       designname: string,

--- a/lib/nano.d.ts
+++ b/lib/nano.d.ts
@@ -61,6 +61,7 @@ declare namespace nano {
     destroy(name: string, callback?: Callback<OkResponse>): Promise<OkResponse>;
     // http://docs.couchdb.org/en/latest/api/server/common.html#get--_all_dbs
     list(callback?: Callback<string[]>): Promise<string[]>;
+    listAsStream(callback?: Callback<string[]>): Request;
     use<D>(db: string): DocumentScope<D>;
     compact(name: string, callback?: Callback<OkResponse>): Promise<OkResponse>;
     // http://docs.couchdb.org/en/latest/api/database/compact.html#post--db-_compact
@@ -151,6 +152,10 @@ declare namespace nano {
     list(callback?: Callback<DocumentListResponse<D>>): Promise<DocumentListResponse<D>>;
     // http://docs.couchdb.org/en/latest/api/database/bulk-api.html#get--db-_all_docs
     list(params: DocumentListParams, callback?: Callback<DocumentListResponse<D>>): Promise<DocumentListResponse<D>>;
+    // http://docs.couchdb.org/en/latest/api/database/bulk-api.html#get--db-_all_docs
+    listAsStream(callback?: Callback<Request>): Request;
+    // http://docs.couchdb.org/en/latest/api/database/bulk-api.html#get--db-_all_docs
+    listAsStream(params: DocumentListParams, callback?: Callback<Request>): Request;
     // http://docs.couchdb.org/en/latest/api/database/bulk-api.html#post--db-_all_docs
     fetch(docnames: BulkFetchDocsWrapper, callback?: Callback<DocumentFetchResponse<D>>): Promise<DocumentFetchResponse<D>>;
     // http://docs.couchdb.org/en/latest/api/database/bulk-api.html#post--db-_all_docs
@@ -304,8 +309,23 @@ declare namespace nano {
       params: any,
       callback?: Callback<DocumentInsertResponse>
     ): Promise<DocumentInsertResponse>;
-    get(docname: string, attname: string): NodeJS.ReadableStream;
+    insertAsStream(
+      docname: string,
+      attname: string,
+      att: any,
+      contenttype: string,
+      callback?: Callback<DocumentInsertResponse>
+    ): Request;
+    insertAsStream(
+      docname: string,
+      attname: string,
+      att: any,
+      contenttype: string,
+      params: any,
+      callback?: Callback<DocumentInsertResponse>
+    ): Request
     get(docname: string, attname: string, callback?: Callback<any>): Promise<any>;
+    getAsStream(docname: string, attname: string): Request;
     get(
       docname: string,
       attname: string,

--- a/lib/nano.d.ts
+++ b/lib/nano.d.ts
@@ -83,6 +83,10 @@ declare namespace nano {
     changes(name: string, callback?: Callback<DatabaseChangesResponse>): Promise<DatabaseChangesResponse>;
     // http://docs.couchdb.org/en/latest/api/database/compact.html#post--db-_compact
     changes(name: string, params: DatabaseChangesParams, callback?: Callback<DatabaseChangesResponse>): Promise<DatabaseChangesResponse>;
+    // http://docs.couchdb.org/en/latest/api/database/changes.html#get--db-_changes
+    changesAsStream(name: string, callback?: Callback<DatabaseChangesResponse>): Request;
+    // http://docs.couchdb.org/en/latest/api/database/compact.html#post--db-_compact
+    changesAsStream(name: string, params: DatabaseChangesParams, callback?: Callback<DatabaseChangesResponse>): Request;
     follow(source: string, callback?: Callback<any>): EventEmitter;
     follow(source: string, params: DatabaseScopeFollowUpdatesParams, callback?: Callback<any>): EventEmitter;
     followUpdates(params?: any, callback?: Callback<any>): EventEmitter;

--- a/lib/nano.d.ts
+++ b/lib/nano.d.ts
@@ -222,14 +222,15 @@ declare namespace nano {
     search<V>(
       designname: string,
       searchname: string,
+      params: DocumentSearchParams,
       callback?: Callback<DocumentSearchResponse<V>>
     ): Promise<DocumentSearchResponse<V>>;
-    search<V>(
+    searchAsStream<V>(
       designname: string,
       searchname: string,
       params: DocumentSearchParams,
       callback?: Callback<DocumentSearchResponse<V>>
-    ): Promise<DocumentSearchResponse<V>>;
+    ): Request;
     spatial(
       ddoc: string,
       viewname: string,

--- a/lib/nano.js
+++ b/lib/nano.js
@@ -863,6 +863,16 @@ module.exports = exports = nano = function dbScope(cfg) {
       }, callback);
     }
 
+    function findAsStream (selector, callback) {
+      return relax({
+        db: dbName,
+        path: '_find',
+        method: 'POST',
+        body: selector,
+        stream: true
+      }, callback);
+    }
+
     function createIndex(indexDef, callback) {
       return relax({
         db: dbName,
@@ -920,6 +930,7 @@ module.exports = exports = nano = function dbScope(cfg) {
       spatial: viewSpatial,
       view: viewDocs,
       find: find,
+      findAsStream: findAsStream,
       createIndex: createIndex,
       viewWithList: viewWithList,
       server: serverScope,

--- a/lib/nano.js
+++ b/lib/nano.js
@@ -69,14 +69,15 @@ module.exports = exports = nano = function dbScope(cfg) {
   }
   const responseHandler = function(req, opts, resolve, reject, callback) {
     
-    return function(e, h, b) {
+    return function(err, response, body) {
       let parsed;
-      const rh = h && h.headers || {};
-      rh.statusCode = h && h.statusCode || 500;
-      rh.uri = req.uri;
-      if (e) {
-        log({err: 'socket', body: b, headers: rh});
-        const ret_e = errs.merge(e, {
+      const responseHeaders = Object.assign({
+        uri: req.uri,
+        statusCode: response ? response.statusCode : 500
+      }, response ? response.headers : {});
+      if (err) {
+        log({err: 'socket', body: body, headers: responseHeaders});
+        const ret_e = errs.merge(err, {
           message: 'error happened in your connection',
           scope: 'socket',
           errid: 'request'
@@ -90,27 +91,27 @@ module.exports = exports = nano = function dbScope(cfg) {
         return ;
       }
 
-      delete rh.server;
-      delete rh['content-length'];
+      delete responseHeaders.server;
+      delete responseHeaders['content-length'];
 
       if (opts.dontParse) {
-        parsed = b;
+        parsed = body;
       } else {
-        try { parsed = JSON.parse(b); } catch (err) { parsed = b; }
+        try { parsed = JSON.parse(body); } catch (err) { parsed = body; }
       }
 
-      if (rh.statusCode >= 200 && rh.statusCode < 400) {
-        log({err: null, body: parsed, headers: rh});
+      if (responseHeaders.statusCode >= 200 && responseHeaders.statusCode < 400) {
+        log({err: null, body: parsed, headers: responseHeaders});
         if (resolve) {
           resolve(parsed);
         } 
         if (callback) {
-          callback(null, parsed, rh);
+          callback(null, parsed, responseHeaders);
         }
         return;
       }
 
-      log({err: 'couch', body: parsed, headers: rh});
+      log({err: 'couch', body: parsed, headers: responseHeaders});
 
       // cloudant stacktrace
       if (typeof parsed === 'string') {
@@ -126,17 +127,17 @@ module.exports = exports = nano = function dbScope(cfg) {
 
       // scrub credentials
       req.uri = scrub(req.uri);
-      rh.uri = scrub(rh.uri);
+      responseHeaders.uri = scrub(responseHeaders.uri);
       if (req.headers.cookie) {
         req.headers.cookie = "XXXXXXX";
       }
 
       let errors = errs.merge({
-        message: 'couch returned ' + rh.statusCode,
+        message: 'couch returned ' + responseHeaders.statusCode,
         scope: 'couch',
-        statusCode: rh.statusCode,
+        statusCode: responseHeaders.statusCode,
         request: req,
-        headers: rh,
+        headers: responseHeaders,
         errid: 'non_200'
       }, errs.create(parsed));
 

--- a/lib/nano.js
+++ b/lib/nano.js
@@ -626,6 +626,10 @@ module.exports = exports = nano = function dbScope(cfg) {
         qs = {};
       }
 
+      if (typeof meta.stream !== 'boolean') {
+        meta.stream = false;
+      }
+
       // prevent mutation of the client qs object by using a clone
       var qs1 = Object.assign({}, qs);
 
@@ -659,22 +663,20 @@ module.exports = exports = nano = function dbScope(cfg) {
           path: viewPath,
           method: 'POST',
           qs: qs1,
-          body: body
+          body: body,
+          stream: meta.stream
         }, callback);
       } else {
         var req = {
           db: dbName,
           method: meta.method || 'GET',
           path: viewPath,
-          qs: qs1
+          qs: qs1,
+          stream: meta.stream
         };
 
         if (meta.body) {
           req.body = meta.body;
-        }
-
-        if (typeof meta.stream === 'boolean') {
-          req.stream = meta.stream;
         }
 
         return relax(req, callback);

--- a/lib/nano.js
+++ b/lib/nano.js
@@ -12,19 +12,19 @@
 
 'use strict';
 
-var u = require('url');
-var assert = require('assert');
-var querystring = require('querystring');
-var request = require('request');
-var errs = require('errs');
-var isEmpty = require('lodash.isempty');
-var follow = require('cloudant-follow');
-var logger = require('./logger');
+const u = require('url');
+const assert = require('assert');
+const querystring = require('querystring');
+const request = require('request');
+const errs = require('errs');
+const isEmpty = require('lodash.isempty');
+const follow = require('cloudant-follow');
+const logger = require('./logger');
 
-var nano;
+let nano;
 
 module.exports = exports = nano = function dbScope(cfg) {
-  var serverScope = {};
+  let serverScope = {};
 
   if (typeof cfg === 'string') {
     cfg = {url: cfg};
@@ -39,21 +39,21 @@ module.exports = exports = nano = function dbScope(cfg) {
   serverScope.config = cfg;
   cfg.requestDefaults = cfg.requestDefaults || {jar: false};
 
-  var httpAgent = (typeof cfg.request === 'function') ? cfg.request :
+  const httpAgent = (typeof cfg.request === 'function') ? cfg.request :
     request.defaults(cfg.requestDefaults);
-  var followAgent = (typeof cfg.follow === 'function') ? cfg.follow : follow;
-  var log = typeof cfg.log === 'function' ? cfg.log : logger(cfg);
-  var parseUrl = 'parseUrl' in cfg ? cfg.parseUrl : true;
+  const followAgent = (typeof cfg.follow === 'function') ? cfg.follow : follow;
+  const log = typeof cfg.log === 'function' ? cfg.log : logger(cfg);
+  const parseUrl = 'parseUrl' in cfg ? cfg.parseUrl : true;
 
   function maybeExtractDatabaseComponent() {
     if (!parseUrl) {
       return;
     }
 
-    var path = u.parse(cfg.url);
-    var pathArray = path.pathname.split('/').filter(function(e) { return e; });
-    var db = pathArray.pop();
-    var rootPath = path.pathname.replace(/\/?$/, '/..');
+    const path = u.parse(cfg.url);
+    let pathArray = path.pathname.split('/').filter(function(e) { return e; });
+    const db = pathArray.pop();
+    const rootPath = path.pathname.replace(/\/?$/, '/..');
 
     if (db) {
       cfg.url = urlResolveFix(cfg.url, rootPath).replace(/\/?$/, '');
@@ -67,16 +67,16 @@ module.exports = exports = nano = function dbScope(cfg) {
     }
     return str;
   }
-  var responseHandler = function(req, opts, resolve, reject, callback) {
+  const responseHandler = function(req, opts, resolve, reject, callback) {
     
     return function(e, h, b) {
-      var parsed;
-      var rh = h && h.headers || {};
+      let parsed;
+      const rh = h && h.headers || {};
       rh.statusCode = h && h.statusCode || 500;
       rh.uri = req.uri;
       if (e) {
         log({err: 'socket', body: b, headers: rh});
-        var ret_e = errs.merge(e, {
+        const ret_e = errs.merge(e, {
           message: 'error happened in your connection',
           scope: 'socket',
           errid: 'request'
@@ -131,7 +131,7 @@ module.exports = exports = nano = function dbScope(cfg) {
         req.headers.cookie = "XXXXXXX";
       }
 
-      var errors = errs.merge({
+      let errors = errs.merge({
         message: 'couch returned ' + rh.statusCode,
         scope: 'couch',
         statusCode: rh.statusCode,
@@ -166,21 +166,21 @@ module.exports = exports = nano = function dbScope(cfg) {
       callback = null;
     }
 
-    var qs = Object.assign({}, opts.qs);
+    const qs = Object.assign({}, opts.qs);
 
-    var headers = {
+    const headers = {
       'content-type': 'application/json',
       accept: 'application/json'
     };
 
-    var req = {
+    const req = {
       method: (opts.method || 'GET'),
       headers: headers,
       uri: cfg.url
     };
 
     // https://github.com/mikeal/request#requestjar
-    var isJar = opts.jar || cfg.jar;
+    const isJar = opts.jar || cfg.jar;
 
     if (isJar) {
       req.jar = isJar;
@@ -446,13 +446,13 @@ module.exports = exports = nano = function dbScope(cfg) {
   }
 
   function docModule(dbName) {
-    var docScope = {};
+    let docScope = {};
     dbName = decodeURIComponent(dbName);
 
     // http://docs.couchdb.org/en/latest/api/document/common.html#put--db-docid
     // http://docs.couchdb.org/en/latest/api/database/common.html#post--db
     function insertDoc(doc, qs, callback) {
-      var opts = {db: dbName, body: doc, method: 'POST'};
+      const opts = {db: dbName, body: doc, method: 'POST'};
 
       if (typeof qs === 'function') {
         callback = qs;
@@ -479,7 +479,7 @@ module.exports = exports = nano = function dbScope(cfg) {
     function destroyDoc(docName, rev, callback) {
       if(!docName) {
         if(callback) {
-          var msg = "Invalid doc id";
+          const msg = 'Invalid doc id';
           callback(msg, null);
           return new Promise(function(resolve, reject) {
             reject(msg);
@@ -544,7 +544,7 @@ module.exports = exports = nano = function dbScope(cfg) {
         opts = {};
       }
 
-      var qs = {
+      const qs = {
         db: dbName,
         doc: docSrc,
         method: 'COPY',
@@ -631,13 +631,13 @@ module.exports = exports = nano = function dbScope(cfg) {
       }
 
       // prevent mutation of the client qs object by using a clone
-      var qs1 = Object.assign({}, qs);
+      const qs1 = Object.assign({}, qs);
 
-      var viewPath = '_design/' + ddoc + '/_' + meta.type + '/'  + viewName;
+      const viewPath = '_design/' + ddoc + '/_' + meta.type + '/'  + viewName;
 
       // Several search parameters must be JSON-encoded; but since this is an
       // object API, several parameters need JSON endoding.
-      var paramsToEncode = ['counts', 'drilldown', 'group_sort', 'ranges', 'sort'];
+      const paramsToEncode = ['counts', 'drilldown', 'group_sort', 'ranges', 'sort'];
       paramsToEncode.forEach(function(param) {
         if (param in qs1) {
           if (typeof qs1[param] !== 'string') {
@@ -656,7 +656,7 @@ module.exports = exports = nano = function dbScope(cfg) {
 
 
       if (qs1 && qs1.keys) {
-        var body = {keys: qs1.keys};
+        const body = {keys: qs1.keys};
         delete qs1.keys;
         return relax({
           db: dbName,
@@ -667,7 +667,7 @@ module.exports = exports = nano = function dbScope(cfg) {
           stream: meta.stream
         }, callback);
       } else {
-        var req = {
+        const req = {
           db: dbName,
           method: meta.method || 'GET',
           path: viewPath,
@@ -756,12 +756,12 @@ module.exports = exports = nano = function dbScope(cfg) {
       }
       qs = qs || {};
 
-      var docName = qs.docName;
+      const docName = qs.docName;
       delete qs.docName;
 
       doc = Object.assign({_attachments: {}}, doc);
 
-      var multipart = [];
+      const multipart = [];
 
       attachments.forEach(function(att) {
         doc._attachments[att.name] = {
@@ -1026,7 +1026,7 @@ module.exports = exports = nano = function dbScope(cfg) {
     uuids: uuids
   });
 
-  var db = maybeExtractDatabaseComponent();
+  const db = maybeExtractDatabaseComponent();
 
   return db ? docModule(db) : serverScope;
 };

--- a/lib/nano.js
+++ b/lib/nano.js
@@ -25,7 +25,6 @@ var nano;
 
 module.exports = exports = nano = function dbScope(cfg) {
   var serverScope = {};
-  var replications = {};
 
   if (typeof cfg === 'string') {
     cfg = {url: cfg};
@@ -86,7 +85,7 @@ module.exports = exports = nano = function dbScope(cfg) {
           reject(ret_e);
         } 
         if (callback) {
-          callback(ret_e)
+          callback(ret_e);
         }
         return ;
       }
@@ -103,12 +102,12 @@ module.exports = exports = nano = function dbScope(cfg) {
       if (rh.statusCode >= 200 && rh.statusCode < 400) {
         log({err: null, body: parsed, headers: rh});
         if (resolve) {
-          resolve(parsed)
+          resolve(parsed);
         } 
         if (callback) {
           callback(null, parsed, rh);
         }
-        return
+        return;
       }
 
       log({err: 'couch', body: parsed, headers: rh});
@@ -274,8 +273,8 @@ module.exports = exports = nano = function dbScope(cfg) {
       return httpAgent(req, responseHandler(req, opts, null, null, callback));
     } else {
       return new Promise( function(resolve, reject) {
-        httpAgent(req, responseHandler(req, opts, resolve, reject, callback))
-      })
+        httpAgent(req, responseHandler(req, opts, resolve, reject, callback));
+      });
     }
   }
 
@@ -480,7 +479,7 @@ module.exports = exports = nano = function dbScope(cfg) {
     function destroyDoc(docName, rev, callback) {
       if(!docName) {
         if(callback) {
-          var msg = "Invalid doc id"
+          var msg = "Invalid doc id";
           callback(msg, null);
           return new Promise(function(resolve, reject) {
             reject(msg);
@@ -628,7 +627,7 @@ module.exports = exports = nano = function dbScope(cfg) {
       }
 
       // prevent mutation of the client qs object by using a clone
-      var qs1 = Object.assign({}, qs)
+      var qs1 = Object.assign({}, qs);
 
       var viewPath = '_design/' + ddoc + '/_' + meta.type + '/'  + viewName;
 

--- a/lib/nano.js
+++ b/lib/nano.js
@@ -635,6 +635,8 @@ module.exports = exports = nano = function dbScope(cfg) {
         }
       });
 
+
+
       if (qs1 && qs1.keys) {
         var body = {keys: qs1.keys};
         delete qs1.keys;
@@ -657,6 +659,10 @@ module.exports = exports = nano = function dbScope(cfg) {
           req.body = meta.body;
         }
 
+        if (typeof meta.stream === 'boolean') {
+          req.stream = meta.stream;
+        }
+
         return relax(req, callback);
       }
     }
@@ -674,6 +680,11 @@ module.exports = exports = nano = function dbScope(cfg) {
     // cloudant
     function viewSearch(ddoc, viewName, qs, callback) {
       return view(ddoc, viewName, {type: 'search'}, qs, callback);
+    }
+
+    // cloudant
+    function viewSearchAsStream(ddoc, viewName, qs, callback) {
+      return view(ddoc, viewName, {type: 'search', stream: true}, qs, callback);
     }
 
     // http://docs.couchdb.org/en/latest/api/ddoc/render.html#get--db-_design-ddoc-_show-func
@@ -927,6 +938,7 @@ module.exports = exports = nano = function dbScope(cfg) {
       atomic: updateWithHandler,
       updateWithHandler: updateWithHandler,
       search: viewSearch,
+      searchAsStream: viewSearchAsStream,
       spatial: viewSpatial,
       view: viewDocs,
       find: find,

--- a/lib/nano.js
+++ b/lib/nano.js
@@ -23,6 +23,17 @@ const logger = require('./logger');
 
 let nano;
 
+function getCallback (opts, callback) {
+  if (typeof opts === 'function') {
+    callback = opts;
+    opts = {};
+  }
+  return {
+    opts,
+    callback
+  };
+}
+
 module.exports = exports = nano = function dbScope(cfg) {
   let serverScope = {};
 
@@ -297,14 +308,11 @@ module.exports = exports = nano = function dbScope(cfg) {
   }
 
   // http://docs.couchdb.org/en/latest/api/server/common.html#get--_db_updates
-  function updates(qs, callback) {
-    if (typeof qs === 'function') {
-      callback = qs;
-      qs = {};
-    }
+  function updates(qs0, callback0) {
+    const {opts, callback} = getCallback(qs0, callback0);
     return relax({
       db: '_db_updates',
-      qs: qs
+      qs: opts
     }, callback);
   }
 
@@ -352,35 +360,23 @@ module.exports = exports = nano = function dbScope(cfg) {
   }
 
   // http://docs.couchdb.org/en/latest/api/database/changes.html#get--db-_changes
-  function changesDb(dbName, qs, callback) {
-    if (typeof qs === 'function') {
-      callback = qs;
-      qs = {};
-    }
-    return relax({db: dbName, path: '_changes', qs: qs}, callback);
+  function changesDb(dbName, qs0, callback0) {
+    const {opts, callback} = getCallback(qs0, callback0);
+    return relax({db: dbName, path: '_changes', qs: opts}, callback);
   }
 
-  function changesDbAsStream(dbName, qs, callback) {
-    if (typeof qs === 'function') {
-      callback = qs;
-      qs = {};
-    }
-    return relax({db: dbName, path: '_changes', stream: true, qs: qs}, callback);
+  function changesDbAsStream(dbName, qs0, callback0) {
+    const {opts, callback} = getCallback(qs0, callback0);
+    return relax({db: dbName, path: '_changes', stream: true, qs: opts}, callback);
   }
 
-  function followDb(dbName, qs, callback) {
-    if (typeof qs === 'function') {
-      callback = qs;
-      qs = {};
-    }
-
-    qs = qs || {};
-    qs.db = urlResolveFix(cfg.url, encodeURIComponent(dbName));
-
+  function followDb(dbName, qs0, callback0) {
+    const {opts, callback} = getCallback(qs0, callback0);
+    opts.db = urlResolveFix(cfg.url, encodeURIComponent(dbName));
     if (typeof callback === 'function') {
-      return followAgent(qs, callback);
+      return followAgent(opts, callback);
     } else {
-      return new followAgent.Feed(qs);
+      return new followAgent.Feed(opts);
     }
   }
 
@@ -393,11 +389,9 @@ module.exports = exports = nano = function dbScope(cfg) {
   }
 
   // http://docs.couchdb.org/en/latest/api/server/common.html#post--_replicate
-  function replicateDb(source, target, opts, callback) {
-    if (typeof opts === 'function') {
-      callback = opts;
-      opts = {};
-    }
+  function replicateDb(source, target, opts0, callback0) {
+    const {opts, callback} = getCallback(opts0, callback0);
+
     // _replicate
     opts.source = _serializeAsUrl(source);
     opts.target = _serializeAsUrl(target);
@@ -411,16 +405,13 @@ module.exports = exports = nano = function dbScope(cfg) {
       callback = count;
       count = 1;
     }
-
     return relax({ method: 'GET', path: '_uuids', qs: {count: count}}, callback);
   }
 
   // http://guide.couchdb.org/draft/replication.html
-  function enableReplication(source, target, opts, callback) {
-    if (typeof opts === 'function') {
-      callback = opts;
-      opts = {};
-    }
+  function enableReplication(source, target, opts0, callback0) {
+    const {opts, callback} = getCallback(opts0, callback0);
+
     // _replicator
     opts.source = _serializeAsUrl(source);
     opts.target = _serializeAsUrl(target);
@@ -429,20 +420,14 @@ module.exports = exports = nano = function dbScope(cfg) {
   }
 
   // http://guide.couchdb.org/draft/replication.html
-  function queryReplication(id, opts, callback) {
-    if (typeof opts === 'function') {
-      callback = opts;
-      opts = {};
-    }
+  function queryReplication(id, opts0, callback0) {
+    const {opts, callback} = getCallback(opts0, callback0);
     return relax({db: '_replicator', method: 'GET', path: id}, callback);
   }
 
   // http://guide.couchdb.org/draft/replication.html
-  function disableReplication(id, rev, opts, callback) {
-    if (typeof opts === 'function') {
-      callback = opts;
-      opts = {};
-    }
+  function disableReplication(id, rev, opts0, callback0) {
+    const {opts, callback} = getCallback(opts0, callback0);
     return relax({db: '_replicator', method: 'DELETE', path: id, qs: {rev: rev}}, callback);
   }
 
@@ -452,28 +437,25 @@ module.exports = exports = nano = function dbScope(cfg) {
 
     // http://docs.couchdb.org/en/latest/api/document/common.html#put--db-docid
     // http://docs.couchdb.org/en/latest/api/database/common.html#post--db
-    function insertDoc(doc, qs, callback) {
-      const opts = {db: dbName, body: doc, method: 'POST'};
+    function insertDoc(doc, qs0, callback0) {
+      const req = {db: dbName, body: doc, method: 'POST'};
 
-      if (typeof qs === 'function') {
-        callback = qs;
-        qs = {};
+      let {opts, callback} = getCallback(qs0, callback0);
+
+      if (typeof opts === 'string') {
+        opts = {docName: opts};
       }
 
-      if (typeof qs === 'string') {
-        qs = {docName: qs};
-      }
-
-      if (qs) {
-        if (qs.docName) {
-          opts.doc = qs.docName;
-          opts.method = 'PUT';
-          delete qs.docName;
+      if (opts) {
+        if (opts.docName) {
+          req.doc = opts.docName;
+          req.method = 'PUT';
+          delete opts.docName;
         }
-        opts.qs = qs;
+        req.qs = opts;
       }
 
-      return relax(opts, callback);
+      return relax(req, callback);
     }
 
     // http://docs.couchdb.org/en/latest/api/document/common.html#delete--db-docid
@@ -498,18 +480,15 @@ module.exports = exports = nano = function dbScope(cfg) {
     }
 
     // http://docs.couchdb.org/en/latest/api/document/common.html#get--db-docid
-    function getDoc(docName, qs, callback) {
-      if (typeof qs === 'function') {
-        callback = qs;
-        qs = {};
-      }
+    function getDoc(docName, qs0, callback0) {
+      const {opts, callback} = getCallback(qs0, callback0);
 
       if(!docName) {
         if(callback)
           callback("Invalid doc id", null);
       }
       else {
-        return relax({db: dbName, doc: docName, qs: qs}, callback);
+        return relax({db: dbName, doc: docName, qs: opts}, callback);
       }
     }
 
@@ -537,11 +516,8 @@ module.exports = exports = nano = function dbScope(cfg) {
     }
 
     // http://docs.couchdb.org/en/latest/api/document/common.html#copy--db-docid
-    function copyDoc(docSrc, docDest, opts, callback) {
-      if (typeof opts === 'function') {
-        callback = opts;
-        opts = {};
-      }
+    function copyDoc(docSrc, docDest, opts0, callback0) {
+      const {opts, callback} = getCallback(opts0, callback0);
 
       const qs = {
         db: dbName,
@@ -567,70 +543,51 @@ module.exports = exports = nano = function dbScope(cfg) {
     }
 
     // http://docs.couchdb.org/en/latest/api/database/bulk-api.html#get--db-_all_docs
-    function listDoc(qs, callback) {
-      if (typeof qs === 'function') {
-        callback = qs;
-        qs = {};
-      }
-
-      return relax({db: dbName, path: '_all_docs', qs: qs}, callback);
+    function listDoc(qs0, callback0) {
+      const {opts, callback} = getCallback(qs0, callback0);
+      return relax({db: dbName, path: '_all_docs', qs: opts}, callback);
     }
 
     // http://docs.couchdb.org/en/latest/api/database/bulk-api.html#get--db-_all_docs
-    function listDocAsStream(qs, callback) {
-      if (typeof qs === 'function') {
-        callback = qs;
-        qs = {};
-      }
-
-      return relax({db: dbName, path: '_all_docs', qs: qs, stream: true}, callback);
+    function listDocAsStream(qs0, callback0) {
+      const {opts, callback} = getCallback(qs0, callback0);
+      return relax({db: dbName, path: '_all_docs', qs: opts, stream: true}, callback);
     }
 
     // http://docs.couchdb.org/en/latest/api/database/bulk-api.html#post--db-_all_docs
-    function fetchDocs(docNames, qs, callback) {
-      if (typeof qs === 'function') {
-        callback = qs;
-        qs = {};
-      }
-
-      qs = qs || {};
-      qs['include_docs'] = true;
+    function fetchDocs(docNames, qs0, callback0) {
+      const {opts, callback} = getCallback(qs0, callback0);
+      opts['include_docs'] = true;
 
       return relax({
         db: dbName,
         path: '_all_docs',
         method: 'POST',
-        qs: qs,
+        qs: opts,
         body: docNames
       }, callback);
     }
 
-    function fetchRevs(docNames, qs, callback) {
-      if (typeof qs === 'function') {
-        callback = qs;
-        qs = {};
-      }
+    function fetchRevs(docNames, qs0, callback0) {
+      const {opts, callback} = getCallback(qs0, callback0);
       return relax({
         db: dbName,
         path: '_all_docs',
         method: 'POST',
-        qs: qs,
+        qs: opts,
         body: docNames
       }, callback);
     }
 
-    function view(ddoc, viewName, meta, qs, callback) {
-      if (typeof qs === 'function') {
-        callback = qs;
-        qs = {};
-      }
+    function view(ddoc, viewName, meta, qs0, callback0) {
+      const {opts, callback} = getCallback(qs0, callback0);
 
       if (typeof meta.stream !== 'boolean') {
         meta.stream = false;
       }
 
       // prevent mutation of the client qs object by using a clone
-      const qs1 = Object.assign({}, qs);
+      const qs1 = Object.assign({}, opts);
 
       const viewPath = '_design/' + ddoc + '/_' + meta.type + '/'  + viewName;
 
@@ -733,18 +690,14 @@ module.exports = exports = nano = function dbScope(cfg) {
     }
 
     // http://docs.couchdb.org/en/latest/api/database/bulk-api.html#post--db-_bulksDoc
-    function bulksDoc(docs, qs, callback) {
-      if (typeof qs === 'function') {
-        callback = qs;
-        qs = {};
-      }
-
+    function bulksDoc(docs, qs0, callback0) {
+      const {opts, callback} = getCallback(qs0, callback0);
       return relax({
         db: dbName,
         path: '_bulk_docs',
         body: docs,
         method: 'POST',
-        qs: qs
+        qs: opts
       }, callback);
     }
 
@@ -788,88 +741,67 @@ module.exports = exports = nano = function dbScope(cfg) {
       }, callback);
     }
 
-    function getMultipart(docName, qs, callback) {
-      if (typeof qs === 'function') {
-        callback = qs;
-        qs = {};
-      }
-      qs = qs || {};
-
-      qs.attachments = true;
+    function getMultipart(docName, qs0, callback0) {
+      const {opts, callback} = getCallback(qs0, callback0);
+      opts.attachments = true;
 
       return relax({
         db: dbName,
         doc: docName,
         encoding: null,
         accept: 'multipart/related',
-        qs: qs
+        qs: opts
       }, callback);
     }
 
-    function insertAtt(docName, attName, att, contentType, qs, callback) {
-      if (typeof qs === 'function') {
-        callback = qs;
-        qs = {};
-      }
-
+    function insertAtt(docName, attName, att, contentType, qs0, callback0) {
+      const {opts, callback} = getCallback(qs0, callback0);
       return relax({
         db: dbName,
         att: attName,
         method: 'PUT',
         contentType: contentType,
         doc: docName,
-        qs: qs,
+        qs: opts,
         body: att,
         dontStringify: true
       }, callback);
     }
 
-    function insertAttAsStream(docName, attName, att, contentType, qs, callback) {
-      if (typeof qs === 'function') {
-        callback = qs;
-        qs = {};
-      }
-
+    function insertAttAsStream(docName, attName, att, contentType, qs0, callback0) {
+      const {opts, callback} = getCallback(qs0, callback0);
       return relax({
         db: dbName,
         att: attName,
         method: 'PUT',
         contentType: contentType,
         doc: docName,
-        qs: qs,
+        qs: opts,
         body: att,
         stream: true,
         dontStringify: true
       }, callback);
     }
 
-    function getAtt(docName, attName, qs, callback) {
-      if (typeof qs === 'function') {
-        callback = qs;
-        qs = {};
-      }
-
+    function getAtt(docName, attName, qs0, callback0) {
+      const {opts, callback} = getCallback(qs0, callback0);
       return relax({
         db: dbName,
         att: attName,
         doc: docName,
-        qs: qs,
+        qs: opts,
         encoding: null,
         dontParse: true
       }, callback);
     }
 
-    function getAttAsStream(docName, attName, qs, callback) {
-      if (typeof qs === 'function') {
-        callback = qs;
-        qs = {};
-      }
-
+    function getAttAsStream(docName, attName, qs0, callback0) {
+      const {opts, callback} = getCallback(qs0, callback0);
       return relax({
         db: dbName,
         att: attName,
         doc: docName,
-        qs: qs,
+        qs: opts,
         stream: true,
         encoding: null,
         dontParse: true

--- a/lib/nano.js
+++ b/lib/nano.js
@@ -672,6 +672,12 @@ module.exports = exports = nano = function dbScope(cfg) {
       return view(ddoc, viewName, {type: 'view'}, qs, callback);
     }
 
+    // http://docs.couchdb.org/en/latest/api/ddoc/views.html#post--db-_design-ddoc-_view-view
+    function viewDocsAsStream(ddoc, viewName, qs, callback) {
+      return view(ddoc, viewName, {type: 'view', stream: true}, qs, callback);
+    }
+    
+
     // geocouch
     function viewSpatial(ddoc, viewName, qs, callback) {
       return view(ddoc, viewName, {type: 'spatial'}, qs, callback);
@@ -941,6 +947,7 @@ module.exports = exports = nano = function dbScope(cfg) {
       searchAsStream: viewSearchAsStream,
       spatial: viewSpatial,
       view: viewDocs,
+      viewAsStream: viewDocsAsStream,
       find: find,
       findAsStream: findAsStream,
       createIndex: createIndex,

--- a/lib/nano.js
+++ b/lib/nano.js
@@ -325,6 +325,11 @@ module.exports = exports = nano = function dbScope(cfg) {
     return relax({db: '_all_dbs'}, callback);
   }
 
+  // http://docs.couchdb.org/en/latest/api/server/common.html#get--_all_dbs
+  function listDbsAsStream(callback) {
+    return relax({db: '_all_dbs', stream: true}, callback);
+  }
+
   // http://docs.couchdb.org/en/latest/api/database/compact.html#post--db-_compact
   function compactDb(dbName, ddoc, callback) {
     if (typeof ddoc === 'function') {
@@ -452,6 +457,33 @@ module.exports = exports = nano = function dbScope(cfg) {
         }
         opts.qs = qs;
       }
+
+      return relax(opts, callback);
+    }
+
+    // http://docs.couchdb.org/en/latest/api/document/common.html#put--db-docid
+    // http://docs.couchdb.org/en/latest/api/database/common.html#post--db
+    function insertDocAsStream(doc, qs, callback) {
+      var opts = {db: dbName, body: doc, method: 'POST'};
+
+      if (typeof qs === 'function') {
+        callback = qs;
+        qs = {};
+      }
+
+      if (typeof qs === 'string') {
+        qs = {docName: qs};
+      }
+
+      if (qs) {
+        if (qs.docName) {
+          opts.doc = qs.docName;
+          opts.method = 'PUT';
+          delete qs.docName;
+        }
+        opts.qs = qs;
+      }
+      opts.stream = true;
 
       return relax(opts, callback);
     }
@@ -757,6 +789,25 @@ module.exports = exports = nano = function dbScope(cfg) {
       }, callback);
     }
 
+    function insertAttAsStream(docName, attName, att, contentType, qs, callback) {
+      if (typeof qs === 'function') {
+        callback = qs;
+        qs = {};
+      }
+
+      return relax({
+        db: dbName,
+        att: attName,
+        method: 'PUT',
+        contentType: contentType,
+        doc: docName,
+        qs: qs,
+        body: att,
+        stream: true,
+        dontStringify: true
+      }, callback);
+    }
+
     function getAtt(docName, attName, qs, callback) {
       if (typeof qs === 'function') {
         callback = qs;
@@ -768,6 +819,23 @@ module.exports = exports = nano = function dbScope(cfg) {
         att: attName,
         doc: docName,
         qs: qs,
+        encoding: null,
+        dontParse: true
+      }, callback);
+    }
+
+    function getAttAsStream(docName, attName, qs, callback) {
+      if (typeof qs === 'function') {
+        callback = qs;
+        qs = {};
+      }
+
+      return relax({
+        db: dbName,
+        att: attName,
+        doc: docName,
+        qs: qs,
+        stream: true,
         encoding: null,
         dontParse: true
       }, callback);
@@ -821,6 +889,7 @@ module.exports = exports = nano = function dbScope(cfg) {
       auth: auth,
       session: session,
       insert: insertDoc,
+      insertAsStream: insertDocAsStream,
       get: getDoc,
       head: headDoc,
       copy: copyDoc,
@@ -836,7 +905,9 @@ module.exports = exports = nano = function dbScope(cfg) {
       },
       attachment: {
         insert: insertAtt,
+        insertAsStream: insertAttAsStream,
         get: getAtt,
+        getAsStream: getAttAsStream,
         destroy: destroyAtt
       },
       show: showDoc,
@@ -876,6 +947,7 @@ module.exports = exports = nano = function dbScope(cfg) {
       get: getDb,
       destroy: destroyDb,
       list: listDbs,
+      listAsStream: listDbsAsStream,
       use: docModule,
       scope: docModule,
       compact: compactDb,

--- a/lib/nano.js
+++ b/lib/nano.js
@@ -527,12 +527,27 @@ module.exports = exports = nano = function dbScope(cfg) {
 
     // http://docs.couchdb.org/en/latest/api/document/common.html#head--db-docid
     function headDoc(docName, callback) {
-      return relax({
-        db: dbName,
-        doc: docName,
-        method: 'HEAD',
-        qs: {}
-      }, callback);
+      // this function doesn't pass on the Promise from relax because it needs
+      // to return the headers when resolving the Promise
+      return new Promise(function(resolve, reject) {
+        relax({
+          db: dbName,
+          doc: docName,
+          method: 'HEAD',
+          qs: {}
+        }, function(err, body, headers) {
+          if (err) {
+            if (callback) {
+              callback(err);
+            }
+            return reject(err);
+          }
+          if (callback) {
+            callback(err, body, headers);
+          }
+          resolve(headers);
+        });
+      });
     }
 
     // http://docs.couchdb.org/en/latest/api/document/common.html#copy--db-docid

--- a/lib/nano.js
+++ b/lib/nano.js
@@ -77,16 +77,16 @@ module.exports = exports = nano = function dbScope(cfg) {
       }, response.headers);
       if (err) {
         log({err: 'socket', body: body, headers: responseHeaders});
-        const ret_e = errs.merge(err, {
+        const returnError = errs.merge(err, {
           message: 'error happened in your connection',
           scope: 'socket',
           errid: 'request'
         });
         if (reject) {
-          reject(ret_e);
+          reject(returnError);
         } 
         if (callback) {
-          callback(ret_e);
+          callback(returnError);
         }
         return ;
       }
@@ -524,16 +524,14 @@ module.exports = exports = nano = function dbScope(cfg) {
           method: 'HEAD',
           qs: {}
         }, function(err, body, headers) {
-          if (err) {
-            if (callback) {
-              callback(err);
-            }
-            return reject(err);
-          }
           if (callback) {
             callback(err, body, headers);
+          } 
+          if (err) {
+            reject(err);
+          } else {
+            resolve(headers)
           }
-          resolve(headers);
         });
       });
     }

--- a/lib/nano.js
+++ b/lib/nano.js
@@ -77,11 +77,18 @@ module.exports = exports = nano = function dbScope(cfg) {
       rh.uri = req.uri;
       if (e) {
         log({err: 'socket', body: b, headers: rh});
-        return callback(errs.merge(e, {
+        var ret_e = errs.merge(e, {
           message: 'error happened in your connection',
           scope: 'socket',
           errid: 'request'
-        }));
+        });
+        if (reject) {
+          reject(ret_e);
+        } 
+        if (callback) {
+          callback(ret_e)
+        }
+        return ;
       }
 
       delete rh.server;
@@ -345,12 +352,12 @@ module.exports = exports = nano = function dbScope(cfg) {
   }
 
   // http://docs.couchdb.org/en/latest/api/database/changes.html#get--db-_changes
-  function changesDb(dbName, qs, callback) {
+  function changesDb(dbName, qs, stream, callback) {
     if (typeof qs === 'function') {
       callback = qs;
       qs = {};
     }
-    return relax({db: dbName, path: '_changes', qs: qs}, callback);
+    return relax({db: dbName, path: '_changes', qs: qs, stream: stream}, callback);
   }
 
   function followDb(dbName, qs, callback) {
@@ -911,7 +918,10 @@ module.exports = exports = nano = function dbScope(cfg) {
         return compactDb(dbName, cb);
       },
       changes: function(qs, cb) {
-        return changesDb(dbName, qs, cb);
+        return changesDb(dbName, qs, false, cb);
+      },
+      changesAsStream: function(qs, cb) {
+        return changesDb(dbName, qs, true, cb);
       },
       follow: function(qs, cb) {
         return followDb(dbName, qs, cb);

--- a/lib/nano.js
+++ b/lib/nano.js
@@ -352,12 +352,20 @@ module.exports = exports = nano = function dbScope(cfg) {
   }
 
   // http://docs.couchdb.org/en/latest/api/database/changes.html#get--db-_changes
-  function changesDb(dbName, qs, stream, callback) {
+  function changesDb(dbName, qs, callback) {
     if (typeof qs === 'function') {
       callback = qs;
       qs = {};
     }
-    return relax({db: dbName, path: '_changes', qs: qs, stream: stream}, callback);
+    return relax({db: dbName, path: '_changes', qs: qs}, callback);
+  }
+
+  function changesDbAsStream(dbName, qs, callback) {
+    if (typeof qs === 'function') {
+      callback = qs;
+      qs = {};
+    }
+    return relax({db: dbName, path: '_changes', stream: true, qs: qs}, callback);
   }
 
   function followDb(dbName, qs, callback) {
@@ -918,10 +926,10 @@ module.exports = exports = nano = function dbScope(cfg) {
         return compactDb(dbName, cb);
       },
       changes: function(qs, cb) {
-        return changesDb(dbName, qs, false, cb);
+        return changesDb(dbName, qs, cb);
       },
       changesAsStream: function(qs, cb) {
-        return changesDb(dbName, qs, true, cb);
+        return changesDbAsStream(dbName, qs, cb);
       },
       follow: function(qs, cb) {
         return followDb(dbName, qs, cb);

--- a/lib/nano.js
+++ b/lib/nano.js
@@ -68,6 +68,82 @@ module.exports = exports = nano = function dbScope(cfg) {
     }
     return str;
   }
+  var responseHandler = function(req, opts, resolve, reject, callback) {
+    
+    return function(e, h, b) {
+      var parsed;
+      var rh = h && h.headers || {};
+      rh.statusCode = h && h.statusCode || 500;
+      rh.uri = req.uri;
+      if (e) {
+        log({err: 'socket', body: b, headers: rh});
+        return callback(errs.merge(e, {
+          message: 'error happened in your connection',
+          scope: 'socket',
+          errid: 'request'
+        }));
+      }
+
+      delete rh.server;
+      delete rh['content-length'];
+
+      if (opts.dontParse) {
+        parsed = b;
+      } else {
+        try { parsed = JSON.parse(b); } catch (err) { parsed = b; }
+      }
+
+      if (rh.statusCode >= 200 && rh.statusCode < 400) {
+        log({err: null, body: parsed, headers: rh});
+        if (resolve) {
+          resolve(parsed)
+        } 
+        if (callback) {
+          callback(null, parsed, rh);
+        }
+        return
+      }
+
+      log({err: 'couch', body: parsed, headers: rh});
+
+      // cloudant stacktrace
+      if (typeof parsed === 'string') {
+        parsed = {message: parsed};
+      }
+
+      if (!parsed.message && (parsed.reason || parsed.error)) {
+        parsed.message = (parsed.reason || parsed.error);
+      }
+
+      // fix cloudant issues where they give an erlang stacktrace as js
+      delete parsed.stack;
+
+      // scrub credentials
+      req.uri = scrub(req.uri);
+      rh.uri = scrub(rh.uri);
+      if (req.headers.cookie) {
+        req.headers.cookie = "XXXXXXX";
+      }
+
+      var errors = errs.merge({
+        message: 'couch returned ' + rh.statusCode,
+        scope: 'couch',
+        statusCode: rh.statusCode,
+        request: req,
+        headers: rh,
+        errid: 'non_200'
+      }, errs.create(parsed));
+
+
+      if (reject) {
+        reject(errors);
+      } 
+      if (callback) {
+        callback(errors);
+      }
+    };
+
+  };
 
   function relax(opts, callback) {
     if (typeof opts === 'function') {
@@ -96,9 +172,6 @@ module.exports = exports = nano = function dbScope(cfg) {
       headers: headers,
       uri: cfg.url
     };
-
-    var parsed;
-    var rh;
 
     // https://github.com/mikeal/request#requestjar
     var isJar = opts.jar || cfg.jar;
@@ -190,67 +263,13 @@ module.exports = exports = nano = function dbScope(cfg) {
 
     log(req);
 
-    if (!callback) {
-      return httpAgent(req);
+    if (opts.stream) {
+      return httpAgent(req, responseHandler(req, opts, null, null, callback));
+    } else {
+      return new Promise( function(resolve, reject) {
+        httpAgent(req, responseHandler(req, opts, resolve, reject, callback))
+      })
     }
-
-    return httpAgent(req, function(e, h, b) {
-      rh = h && h.headers || {};
-      rh.statusCode = h && h.statusCode || 500;
-      rh.uri = req.uri;
-      if (e) {
-        log({err: 'socket', body: b, headers: rh});
-        return callback(errs.merge(e, {
-          message: 'error happened in your connection',
-          scope: 'socket',
-          errid: 'request'
-        }));
-      }
-
-      delete rh.server;
-      delete rh['content-length'];
-
-      if (opts.dontParse) {
-        parsed = b;
-      } else {
-        try { parsed = JSON.parse(b); } catch (err) { parsed = b; }
-      }
-
-      if (rh.statusCode >= 200 && rh.statusCode < 400) {
-        log({err: null, body: parsed, headers: rh});
-        return callback(null, parsed, rh);
-      }
-
-      log({err: 'couch', body: parsed, headers: rh});
-
-      // cloudant stacktrace
-      if (typeof parsed === 'string') {
-        parsed = {message: parsed};
-      }
-
-      if (!parsed.message && (parsed.reason || parsed.error)) {
-        parsed.message = (parsed.reason || parsed.error);
-      }
-
-      // fix cloudant issues where they give an erlang stacktrace as js
-      delete parsed.stack;
-
-      // scrub credentials
-      req.uri = scrub(req.uri);
-      rh.uri = scrub(rh.uri);
-      if (req.headers.cookie) {
-        req.headers.cookie = "XXXXXXX";
-      }
-
-      callback(errs.merge({
-        message: 'couch returned ' + rh.statusCode,
-        scope: 'couch',
-        statusCode: rh.statusCode,
-        request: req,
-        headers: rh,
-        errid: 'non_200'
-      }, errs.create(parsed)));
-    });
   }
 
   // http://docs.couchdb.org/en/latest/api/server/authn.html#cookie-authentication

--- a/lib/nano.js
+++ b/lib/nano.js
@@ -80,7 +80,7 @@ module.exports = exports = nano = function dbScope(cfg) {
   }
   const responseHandler = function(req, opts, resolve, reject, callback) {
     
-    return function(err, response = { statusCode: 500 }, body) {
+    return function(err, response = { statusCode: 500 }, body = '') {
       let parsed;
       const responseHeaders = Object.assign({
         uri: req.uri,
@@ -422,13 +422,19 @@ module.exports = exports = nano = function dbScope(cfg) {
   // http://guide.couchdb.org/draft/replication.html
   function queryReplication(id, opts0, callback0) {
     const {opts, callback} = getCallback(opts0, callback0);
-    return relax({db: '_replicator', method: 'GET', path: id}, callback);
+    return relax({db: '_replicator', method: 'GET', path: id, qs: opts}, callback);
   }
 
   // http://guide.couchdb.org/draft/replication.html
   function disableReplication(id, rev, opts0, callback0) {
     const {opts, callback} = getCallback(opts0, callback0);
-    return relax({db: '_replicator', method: 'DELETE', path: id, qs: {rev: rev}}, callback);
+    const req = {
+      db: '_replicator', 
+      method: 'DELETE', 
+      path: id, 
+      qs: Object.assign(opts, {rev: rev})
+    };
+    return relax(req, callback);
   }
 
   function docModule(dbName) {
@@ -509,7 +515,7 @@ module.exports = exports = nano = function dbScope(cfg) {
           if (err) {
             reject(err);
           } else {
-            resolve(headers)
+            resolve(headers);
           }
         });
       });

--- a/lib/nano.js
+++ b/lib/nano.js
@@ -461,33 +461,6 @@ module.exports = exports = nano = function dbScope(cfg) {
       return relax(opts, callback);
     }
 
-    // http://docs.couchdb.org/en/latest/api/document/common.html#put--db-docid
-    // http://docs.couchdb.org/en/latest/api/database/common.html#post--db
-    function insertDocAsStream(doc, qs, callback) {
-      var opts = {db: dbName, body: doc, method: 'POST'};
-
-      if (typeof qs === 'function') {
-        callback = qs;
-        qs = {};
-      }
-
-      if (typeof qs === 'string') {
-        qs = {docName: qs};
-      }
-
-      if (qs) {
-        if (qs.docName) {
-          opts.doc = qs.docName;
-          opts.method = 'PUT';
-          delete qs.docName;
-        }
-        opts.qs = qs;
-      }
-      opts.stream = true;
-
-      return relax(opts, callback);
-    }
-
     // http://docs.couchdb.org/en/latest/api/document/common.html#delete--db-docid
     function destroyDoc(docName, rev, callback) {
       if(!docName) {
@@ -588,6 +561,16 @@ module.exports = exports = nano = function dbScope(cfg) {
       }
 
       return relax({db: dbName, path: '_all_docs', qs: qs}, callback);
+    }
+
+    // http://docs.couchdb.org/en/latest/api/database/bulk-api.html#get--db-_all_docs
+    function listDocAsStream(qs, callback) {
+      if (typeof qs === 'function') {
+        callback = qs;
+        qs = {};
+      }
+
+      return relax({db: dbName, path: '_all_docs', qs: qs, stream: true}, callback);
     }
 
     // http://docs.couchdb.org/en/latest/api/database/bulk-api.html#post--db-_all_docs
@@ -909,13 +892,13 @@ module.exports = exports = nano = function dbScope(cfg) {
       auth: auth,
       session: session,
       insert: insertDoc,
-      insertAsStream: insertDocAsStream,
       get: getDoc,
       head: headDoc,
       copy: copyDoc,
       destroy: destroyDoc,
       bulk: bulksDoc,
       list: listDoc,
+      listAsStream: listDocAsStream,
       fetch: fetchDocs,
       fetchRevs: fetchRevs,
       config: {url: cfg.url, db: dbName},

--- a/lib/nano.js
+++ b/lib/nano.js
@@ -69,12 +69,12 @@ module.exports = exports = nano = function dbScope(cfg) {
   }
   const responseHandler = function(req, opts, resolve, reject, callback) {
     
-    return function(err, response, body) {
+    return function(err, response = { statusCode: 500 }, body) {
       let parsed;
       const responseHeaders = Object.assign({
         uri: req.uri,
-        statusCode: response ? response.statusCode : 500
-      }, response ? response.headers : {});
+        statusCode: response.statusCode
+      }, response.headers);
       if (err) {
         log({err: 'socket', body: body, headers: responseHeaders});
         const ret_e = errs.merge(err, {

--- a/lib/nano.js
+++ b/lib/nano.js
@@ -491,8 +491,13 @@ module.exports = exports = nano = function dbScope(cfg) {
     // http://docs.couchdb.org/en/latest/api/document/common.html#delete--db-docid
     function destroyDoc(docName, rev, callback) {
       if(!docName) {
-        if(callback)
-          callback("Invalid doc id", null);
+        if(callback) {
+          var msg = "Invalid doc id"
+          callback(msg, null);
+          return new Promise(function(resolve, reject) {
+            reject(msg);
+          });
+        }
       }
       else {
         return relax({

--- a/migration_6_to_7.md
+++ b/migration_6_to_7.md
@@ -18,6 +18,9 @@ In Nano 7:
 // Nano 7
 const db = nano.db.use('mydb')
 const x = await db.get('mydoc') 
+// the return value of db.get is a Promise, 
+// the 'await' operator waits for the Promise to resolve and 
+// x is your requested CouchDB object
 ```
 
 If you are not using the streaming properties of Nano 6's return value, you may not need to change any code at all. This document outlines the areas that have changed and what you need to do to your code.
@@ -67,7 +70,7 @@ db.get('mydoc').then((doc) => {
 })
 ```
 
-The Promise style of code lets you code sequences of asynchronou calls at the same level of indentation (the callback style forces you to indent further to the right with each call!):
+The Promise style of code lets you code sequences of asynchronous calls at the same level of indentation (the callback style forces you to indent further to the right with each call!):
 
 ```js
 db.get('mydoc').then((doc) => {

--- a/migration_6_to_7.md
+++ b/migration_6_to_7.md
@@ -93,4 +93,5 @@ You may find that using the Promise style of coding helps you create neater, sim
 
 ## TypeScript
 
-If you use TypeScript to build your app, then Nano's TypeScript definitions have been updated to reflect the new return values. Having the Nano `get` function, for example, return a Promise which resolves with a `nano.DocumentGetResponse` means that your code editor can give you a helping hand with code completion, type-checking and a sanity checks which will help you write more accurate code at the first attempt.
+If you use TypeScript to build your app, then Nano's TypeScript definitions have been updated to reflect the new return values. Having the Nano `get` function, for example, return a Promise which resolves with a `nano.DocumentGetResponse` means that your code editor can give you a helping hand with code completion, type-checking and a sanity checks leading to more accurate code at the first attempt.
+

--- a/migration_6_to_7.md
+++ b/migration_6_to_7.md
@@ -1,0 +1,96 @@
+# Migration Guide for moving from Nano 6.x to 7.x
+
+Version 7.0.0 saw a major switch in return values from the majority of Nano functions. The version 6 version of Nano always returned a [request](https://www.npmjs.com/package/request) object from any function call that made an HTTP/HTTPS request.
+
+
+In Nano 6:
+
+```js
+// Nano 6
+var db = nano.db.use('mydb')
+var x = db.get('mydoc') 
+// x is a request object
+```
+
+In Nano 7:
+
+```js
+// Nano 7
+var db = nano.db.use('mydb')
+var x = db.get('mydoc') 
+// x is a Promise
+```
+
+If you are not using the streaming properties of Nano 6's return value, you may not need to change any code at all. This document outlines the areas that have changed and what you need to do to your code.
+
+## Streaming
+
+If you were using the returned request object to:
+
+- pipe the result to another stream
+- listen to HTTP events ( `.on('data', function() {} )` etc)
+
+then **you will need to change your code** to make it work with Nano v7. There are handful of new `..AsStream` function calls the *do* return a request object. They are:
+
+- nano.db.listAsStream - fetch a list of database names
+- db.attachment.insertAsStream - insert an attachment from a stream
+- db.attachment.getAsStream - retrieve an attachment as a stream
+- db.listAsStream - fetch a list of documents 
+- db.findAsStream - query a database using a "Mango" selector
+- db.searchAsStream - perform a Lucene-style query
+- db.viewAsStream - query a MapReduce view
+- db.changesAsStream - fetch a database's changes feed
+
+There are non-streaming versions of all of the above functions that return a Promise - simply remove the "AsStream" suffix.
+
+There isn't an `...AsStream` function for every CouchDB operation - only for ones which may result in lots of data being moved around or where binary data is being passed around (attachments). The streaming functions are useful to pipe data data through your app between CouchDB and your client without your app having to buffer all of the data in memory at once. 
+
+## Promises
+
+In Nano 7, most functions return a native [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) instead of a request object.
+
+If you have code in the *callback* style, then Nano 7 will still work:
+
+```js
+// Nano 7
+db.get('mydoc', function(err, data)  {
+  console.log(err, data)
+})
+```
+
+but you have the option of using the returned *Promise* to deal with the return of asynchronous data:
+
+```js
+db.get('mydoc').then((doc) => {
+  console.log(doc)
+}).catch((err) => {
+  console.log(err)
+})
+```
+
+The Promise style of code lets you code sequences of asynchronou calls at the same level of indentation (the callback style forces you to indent further to the right with each call!):
+
+```js
+db.get('mydoc').then((doc) => {
+  doc.last_updated = new Date().getTime()
+  return db.insert(doc)
+}.then((response) => {
+  console.log('doc updated')
+}).catch((err) => {
+  console.log(err)
+})
+```
+
+In a JavaScript [async function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function), the code becomes even neater with the [await operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await):
+
+```js
+var doc = await db.get('mydoc')
+doc.last_updated = new Date().getTime()
+var response = await db.insert(doc)
+```
+
+You may find that using the Promise style of coding helps you create neater, simpler code, but pre-existing code that uses the callback style should still work.
+
+## TypeScript
+
+If you use TypeScript to build your app, then Nano's TypeScript definitions have been updated to reflect the new return values. Having the Nano `get` function, for example, return a Promise which resolves with a `nano.DocumentGetResponse` means that your code editor can give you a helping hand with code completion, type-checking and a sanity checks which will help you write more accurate code at the first attempt.

--- a/migration_6_to_7.md
+++ b/migration_6_to_7.md
@@ -16,9 +16,8 @@ In Nano 7:
 
 ```js
 // Nano 7
-var db = nano.db.use('mydb')
-var x = db.get('mydoc') 
-// x is a Promise
+const db = nano.db.use('mydb')
+const x = await db.get('mydoc') 
 ```
 
 If you are not using the streaming properties of Nano 6's return value, you may not need to change any code at all. This document outlines the areas that have changed and what you need to do to your code.
@@ -53,7 +52,7 @@ If you have code in the *callback* style, then Nano 7 will still work:
 
 ```js
 // Nano 7
-db.get('mydoc', function(err, data)  {
+db.get('mydoc', (err, data) => {
   console.log(err, data)
 })
 ```
@@ -84,9 +83,9 @@ db.get('mydoc').then((doc) => {
 In a JavaScript [async function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function), the code becomes even neater with the [await operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await):
 
 ```js
-var doc = await db.get('mydoc')
+let doc = await db.get('mydoc')
 doc.last_updated = new Date().getTime()
-var response = await db.insert(doc)
+let response = await db.insert(doc)
 ```
 
 You may find that using the Promise style of coding helps you create neater, simpler code, but pre-existing code that uses the callback style should still work.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1748,9 +1748,9 @@
       "dev": true
     },
     "stringstream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
+      "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA=="
     },
     "strip-ansi": {
       "version": "3.0.1",

--- a/scripts/run_couchdb_on_travis.sh
+++ b/scripts/run_couchdb_on_travis.sh
@@ -3,7 +3,7 @@
 if [ ! -z $TRAVIS ]; then
 	# Install CouchDB Master
 	echo "Starting CouchDB 2.0 Docker"
-	docker run --ulimit nofile=2048:2048 -d -p 5984:5984 klaemo/couchdb:2.0-dev@sha256:336fd3d9a89475205fc79b6a287ee550d258fac3b62c67b8d13b8e66c71d228f --with-haproxy \
+	docker run --ulimit nofile=2048:2048 -d -p 5984:5984 couchdb --with-haproxy \
 	    --with-admin-party-please -n 1
 
 	# wait for couchdb to start

--- a/tests/fixtures/attachment/pipe.json
+++ b/tests/fixtures/attachment/pipe.json
@@ -14,6 +14,10 @@
   , "status"   : 200
   , "buffer"   : "Qk06AAAAAAAAADYAAAAoAAAAAQAAAP////8BABgAAAAAAAAAAAATCwAAEwsAAAAAAAAAAAAAWm2CAA=="
   }
+, { "path"     : "/attachment_pipe/new/att"
+  , "status"   : 200
+  , "buffer"   : "Qk06AAAAAAAAADYAAAAoAAAAAQAAAP////8BABgAAAAAAAAAAAATCwAAEwsAAAAAAAAAAAAAWm2CAA=="
+  }
 , { "method"   : "put"
   , "path"     : "/attachment_pipe/nodejs/logo.png"
   , "body"     : "*"

--- a/tests/fixtures/database/changes.json
+++ b/tests/fixtures/database/changes.json
@@ -30,6 +30,10 @@
   , "path"     : "/database_changes/_changes?since=0"
   , "response" : "{\"results\":[{\"seq\":\"1-abc\",\"id\":\"a\",\"changes\":[{\"rev\":\"1-abc\"}]},{\"seq\":\"2-abc\",\"id\":\"b\",\"changes\":[{\"rev\":\"1-abc\"}]},{\"seq\":\"3-abc\",\"id\":\"c\",\"changes\":[{\"rev\":\"1-abc\"}]}],\"last_seq\":\"3-abc\"}"
   }
+, { "status"   : 200
+  , "path"     : "/database_changes/_changes"
+  , "response" : "{\"results\":[],\"last_seq\":\"3-abc\"}"
+  }
 , { "method"   : "delete"
   , "path"     : "/database_changes"
   , "status"   : 200

--- a/tests/fixtures/database/changes.json
+++ b/tests/fixtures/database/changes.json
@@ -26,6 +26,10 @@
   , "path"     : "/database_changes/_changes?since=0"
   , "response" : "{\"results\":[{\"seq\":\"1-abc\",\"id\":\"a\",\"changes\":[{\"rev\":\"1-abc\"}]},{\"seq\":\"2-abc\",\"id\":\"b\",\"changes\":[{\"rev\":\"1-abc\"}]},{\"seq\":\"3-abc\",\"id\":\"c\",\"changes\":[{\"rev\":\"1-abc\"}]}],\"last_seq\":\"3-abc\"}"
   }
+, { "status"   : 200
+  , "path"     : "/database_changes/_changes?since=0"
+  , "response" : "{\"results\":[{\"seq\":\"1-abc\",\"id\":\"a\",\"changes\":[{\"rev\":\"1-abc\"}]},{\"seq\":\"2-abc\",\"id\":\"b\",\"changes\":[{\"rev\":\"1-abc\"}]},{\"seq\":\"3-abc\",\"id\":\"c\",\"changes\":[{\"rev\":\"1-abc\"}]}],\"last_seq\":\"3-abc\"}"
+  }
 , { "method"   : "delete"
   , "path"     : "/database_changes"
   , "status"   : 200

--- a/tests/fixtures/design/multiple.json
+++ b/tests/fixtures/design/multiple.json
@@ -33,6 +33,11 @@
   , "method"   : "post"
   , "response" : "{\"total_rows\":3,\"offset\":2,\"rows\":[\r\n{\"id\":\"foobar\",\"key\":\"foobar\",\"value\":{\"_id\":\"foobar\",\"_rev\":\"1-4c6114c65e295552ab1019e2b046b10e\",\"foo\":\"bar\"},\"doc\":{\"_id\":\"foobar\",\"_rev\":\"1-4c6114c65e295552ab1019e2b046b10e\",\"foo\":\"bar\"}},\r\n{\"id\":\"barfoo\",\"key\":\"barfoo\",\"value\":{\"_id\":\"barfoo\",\"_rev\":\"1-41412c293dade3fe73279cba8b4cece4\",\"bar\":\"foo\"},\"doc\":{\"_id\":\"barfoo\",\"_rev\":\"1-41412c293dade3fe73279cba8b4cece4\",\"bar\":\"foo\"}}\r\n]}\n"
   }
+, { "path"     : "/design_multiple/_design/alice/_view/by_id?include_docs=true"
+  , "body"     : "{\"keys\":[\"foobar\",\"barfoo\"]}"
+  , "method"   : "post"
+  , "response" : "{\"total_rows\":3,\"offset\":2,\"rows\":[\r\n{\"id\":\"foobar\",\"key\":\"foobar\",\"value\":{\"_id\":\"foobar\",\"_rev\":\"1-4c6114c65e295552ab1019e2b046b10e\",\"foo\":\"bar\"},\"doc\":{\"_id\":\"foobar\",\"_rev\":\"1-4c6114c65e295552ab1019e2b046b10e\",\"foo\":\"bar\"}},\r\n{\"id\":\"barfoo\",\"key\":\"barfoo\",\"value\":{\"_id\":\"barfoo\",\"_rev\":\"1-41412c293dade3fe73279cba8b4cece4\",\"bar\":\"foo\"},\"doc\":{\"_id\":\"barfoo\",\"_rev\":\"1-41412c293dade3fe73279cba8b4cece4\",\"bar\":\"foo\"}}\r\n]}\n"
+  }
 , { "method"   : "delete"
   , "path"     : "/design_multiple"
   , "status"   : 200

--- a/tests/fixtures/document/find.json
+++ b/tests/fixtures/document/find.json
@@ -1,0 +1,36 @@
+[
+  { "method"   : "put"
+  , "path"     : "/document_find"
+  , "status"   : 201
+  , "response" : "{ \"ok\": true }"
+  }
+, { "method"   : "put"
+  , "status"   : 201
+  , "path"     : "/document_find/foobar"
+  , "body"     : "{\"foo\":\"bar\"}"
+  , "response" : "{\"ok\":true,\"id\":\"foobar\",\"rev\":\"1-4c6114\"}"
+  }
+, { "method"   : "put"
+  , "status"   : 201
+  , "path"     : "/document_find/foobaz"
+  , "body"     : "{\"foo\":\"baz\"}"
+  , "response" : "{\"ok\":true,\"id\":\"foobaz\",\"rev\":\"1-611488\"}"
+  }
+, { "method"   : "put"
+  , "status"   : 201
+  , "path"     : "/document_find/barfoo"
+  , "body"     : "{\"bar\":\"foo\"}"
+  , "response" : "{\"ok\":true,\"id\":\"barfoo\",\"rev\":\"1-3cde10\"}"
+  }
+, { "path"     : "/document_find/_find"
+  , "response" : "{ \"docs\" : [ { \"_id\":  \"foobaz\", \"rev\":\"1-611488\", \"foo\":\"baz\" }]}"
+  }
+, { "path"     : "/document_find/_find"
+  , "response" : "{ \"docs\" : [ { \"_id\":  \"foobaz\", \"rev\":\"1-611488\", \"foo\":\"baz\" }]}"
+  }
+, { "method"   : "delete"
+  , "path"     : "/document_find"
+  , "status"   : 200
+  , "response" : "{ \"ok\": true }"
+  }
+]

--- a/tests/fixtures/document/insert.json
+++ b/tests/fixtures/document/insert.json
@@ -31,12 +31,6 @@
 , { "path"     : "/document_insert/123"
   , "response" : "{\"fn\":\"function() { return true; }\",\"fn2\":\"function() { return true; }\",\"id\":\"123\",\"rev\":\"1-611488\"}"
   }
-, { "method"   : "post"
-  , "status"   : 201
-  , "path"     : "/document_insert"
-  , "body"     : "{\"foo\":\"bar\"}"
-  , "response" : "{\"ok\":true,\"id\":\"234\",\"rev\":\"1-333231\"}"
-  }
 , { "method"   : "delete"
   , "path"     : "/document_insert/foobaz?rev=1-611488"
   , "response" : "{\"ok\":true}"

--- a/tests/fixtures/document/list.json
+++ b/tests/fixtures/document/list.json
@@ -40,6 +40,12 @@
 , { "path"     : "/document_list/_all_docs?end_key=%22s%22"
   , "response" : "{\"total_rows\":3,\"offset\": 1,\"rows\":[\r\n{\"id\":\"foobar\",\"key\":\"foobar\",\"value\":{\"_id\":\"foobar\",\"_rev\":\"1-4c6114c65e295552ab1019e2b046b10e\",\"foo\":\"bar\"},\"doc\":{\"_id\":\"foobar\",\"_rev\":\"1-4c6114c65e295552ab1019e2b046b10e\",\"foo\":\"bar\"}},\r\n{\"id\":\"barfoo\",\"key\":\"barfoo\",\"value\":{\"_id\":\"barfoo\",\"_rev\":\"1-41412c293dade3fe73279cba8b4cece4\",\"bar\":\"foo\"},\"doc\":{\"_id\":\"barfoo\",\"_rev\":\"1-41412c293dade3fe73279cba8b4cece4\",\"bar\":\"foo\"}}\r\n]}"
   }
+, { "path"     : "/document_list/_all_docs"
+  , "response" : "{\"total_rows\":3,\"offset\": 1,\"rows\":[\r\n{\"id\":\"foobar\",\"key\":\"foobar\",\"value\":{\"_id\":\"foobar\",\"_rev\":\"1-4c6114c65e295552ab1019e2b046b10e\",\"foo\":\"bar\"},\"doc\":{\"_id\":\"foobar\",\"_rev\":\"1-4c6114c65e295552ab1019e2b046b10e\",\"foo\":\"bar\"}},\r\n{\"id\":\"barfoo\",\"key\":\"barfoo\",\"value\":{\"_id\":\"barfoo\",\"_rev\":\"1-41412c293dade3fe73279cba8b4cece4\",\"bar\":\"foo\"},\"doc\":{\"_id\":\"barfoo\",\"_rev\":\"1-41412c293dade3fe73279cba8b4cece4\",\"bar\":\"foo\"}}\r\n]}"
+  }
+, { "path"     : "/document_list/_all_docs?end_key=%22s%22"
+  , "response" : "{\"total_rows\":3,\"offset\": 1,\"rows\":[\r\n{\"id\":\"foobar\",\"key\":\"foobar\",\"value\":{\"_id\":\"foobar\",\"_rev\":\"1-4c6114c65e295552ab1019e2b046b10e\",\"foo\":\"bar\"},\"doc\":{\"_id\":\"foobar\",\"_rev\":\"1-4c6114c65e295552ab1019e2b046b10e\",\"foo\":\"bar\"}},\r\n{\"id\":\"barfoo\",\"key\":\"barfoo\",\"value\":{\"_id\":\"barfoo\",\"_rev\":\"1-41412c293dade3fe73279cba8b4cece4\",\"bar\":\"foo\"},\"doc\":{\"_id\":\"barfoo\",\"_rev\":\"1-41412c293dade3fe73279cba8b4cece4\",\"bar\":\"foo\"}}\r\n]}"
+  }
 , { "method"   : "delete"
   , "path"     : "/document_list"
   , "status"   : 200

--- a/tests/helpers/index.js
+++ b/tests/helpers/index.js
@@ -12,14 +12,14 @@
 
 'use strict';
 
-var path = require('path');
-var fs = require('fs');
-var url = require('url');
-var nano = require('../../lib/nano');
+const path = require('path');
+const fs = require('fs');
+const url = require('url');
+const nano = require('../../lib/nano');
 
-var helpers = exports;
-var cfg = helpers.cfg = require('../fixtures/cfg');
-var auth = url.parse(cfg.admin).auth.split(':');
+const helpers = exports;
+const cfg = helpers.cfg = require('../fixtures/cfg');
+const auth = url.parse(cfg.admin).auth.split(':');
 
 helpers.noopTest = function(t){ t.end(); };
 helpers.timeout = cfg.timeout;
@@ -34,7 +34,7 @@ helpers.username = auth[0];
 helpers.password = auth[1];
 
 helpers.loadFixture = function helpersLoadFixture(filename, json) {
-  var contents = fs.readFileSync(
+  const contents = fs.readFileSync(
     path.join(__dirname, '..', 'fixtures', filename), (json ? 'ascii' : null));
   return json ? JSON.parse(contents) : contents;
 };

--- a/tests/helpers/integration.js
+++ b/tests/helpers/integration.js
@@ -188,5 +188,9 @@ helpers.insertThree = function insertThree(assert) {
 helpers.unmocked = (process.env.NOCK_OFF === 'true');
 helpers.mocked = !helpers.unmocked;
 
+helpers.isPromise = function(p) {
+  return (p && typeof p === 'object' && typeof p.then === 'function') 
+}
+
 module.exports = helpers;
 

--- a/tests/helpers/integration.js
+++ b/tests/helpers/integration.js
@@ -12,18 +12,18 @@
 
 'use strict';
 
-var async = require('async');
-var debug = require('debug');
-var path = require('path');
-var harness = require('tape-it');
-var endsWith = require('endswith');
-var cfg = require('../fixtures/cfg');
-var nano = require('../../lib/nano');
-var helpers = require('./');
+const async = require('async');
+const debug = require('debug');
+const path = require('path');
+const harness = require('tape-it');
+const endsWith = require('endswith');
+const cfg = require('../fixtures/cfg');
+const nano = require('../../lib/nano');
+const helpers = require('./');
 
 helpers.setup = function() {
-  var self = this;
-  var args = Array.prototype.slice.call(arguments);
+  const self = this;
+  const args = Array.prototype.slice.call(arguments);
 
   return function(assert) {
     args.push(function(err) {
@@ -36,8 +36,8 @@ helpers.setup = function() {
 };
 
 helpers.teardown = function() {
-  var self = this;
-  var args = Array.prototype.slice.call(arguments);
+  const self = this;
+  const args = Array.prototype.slice.call(arguments);
 
   return function(assert) {
     args.push(function(err) {
@@ -51,21 +51,21 @@ helpers.teardown = function() {
 };
 
 helpers.harness = function(name, setup, teardown) {
-  var parent = name || module.parent.filename;
-  var fileName = path.basename(parent).split('.')[0];
-  var parentDir = path.dirname(parent)
+  const parent = name || module.parent.filename;
+  const fileName = path.basename(parent).split('.')[0];
+  const parentDir = path.dirname(parent)
     .split(path.sep).reverse()[0];
-  var shortPath = path.join(parentDir, fileName);
-  var log = debug(path.join('nano', 'tests', 'integration', shortPath));
-  var dbName = shortPath.replace('/', '_');
-  var nanoLog = nano({
+  const shortPath = path.join(parentDir, fileName);
+  const log = debug(path.join('nano', 'tests', 'integration', shortPath));
+  const dbName = shortPath.replace('/', '_');
+  const nanoLog = nano({
     url: cfg.couch,
     log: log
   });
 
-  var mock = helpers.nock(helpers.couch, shortPath, log);
-  var db   = nanoLog.use(dbName);
-  var locals = {
+  const mock = helpers.nock(helpers.couch, shortPath, log);
+  const db   = nanoLog.use(dbName);
+  const locals = {
     mock: mock,
     db: db,
     nano: nanoLog
@@ -82,15 +82,15 @@ helpers.harness = function(name, setup, teardown) {
 };
 
 helpers.nock = function helpersNock(url, fixture, log) {
-  var nock = require('nock');
-  var nockDefs = require('../fixtures/' + fixture + '.json');
+  const nock = require('nock');
+  const nockDefs = require('../fixtures/' + fixture + '.json');
 
   nockDefs.forEach(function(n) {
-    var headers = n.headers || {};
-    var response = n.buffer ? endsWith(n.buffer, '.png') ?
+    let headers = n.headers || {};
+    const response = n.buffer ? endsWith(n.buffer, '.png') ?
         helpers.loadFixture(n.buffer) : new Buffer(n.buffer, 'base64') :
         n.response || '';
-    var body = n.base64 ? new Buffer(n.base64, 'base64').toString() :
+        const body = n.base64 ? new Buffer(n.base64, 'base64').toString() :
         n.body || '';
 
     if (typeof headers === 'string' && endsWith(headers, '.json')) {
@@ -166,7 +166,7 @@ helpers.viewDerek = function viewDerek(db, assert, opts, next, method) {
 };
 
 helpers.insertOne = function insertThree(assert) {
-  var db = this.db;
+  const db = this.db;
   db.insert({'foo': 'baz'}, 'foobaz', function(err) {
     assert.equal(err, null, 'should store docs');
     assert.end();
@@ -174,7 +174,7 @@ helpers.insertOne = function insertThree(assert) {
 };
 
 helpers.insertThree = function insertThree(assert) {
-  var db = this.db;
+  const db = this.db;
   async.parallel([
     function(cb) { db.insert({'foo': 'bar'}, 'foobar', cb); },
     function(cb) { db.insert({'bar': 'foo'}, 'barfoo', cb); },

--- a/tests/helpers/unit.js
+++ b/tests/helpers/unit.js
@@ -12,20 +12,20 @@
 
 'use strict';
 
-var helpers = require('./');
-var Client = require('../../lib/nano');
-var test  = require('tape');
-var _ = require('underscore');
+const helpers = require('./');
+const Client = require('../../lib/nano');
+const test  = require('tape');
+const _ = require('underscore');
 
 helpers.unit = function(method, error) {
-  var unitName = 'nano/tests/unit/' + method.join('/');
-  var debug = require('debug')(unitName);
+  const unitName = 'nano/tests/unit/' + method.join('/');
+  const debug = require('debug')(unitName);
 
   function log(data) {
     debug({ got: data.body });
   }
 
-  var cli = helpers.mockClientOk(log, error);
+  let cli = helpers.mockClientOk(log, error);
 
   //
   // allow database creation and other server stuff
@@ -40,15 +40,15 @@ helpers.unit = function(method, error) {
     cli.server = helpers.mockClientDb(log, error);
   }
 
-  var testNr = 1;
+  let testNr = 1;
 
   return function() {
-    var args = Array.prototype.slice.call(arguments);
-    var stub = args.pop();
+    const args = Array.prototype.slice.call(arguments);
+    const stub = args.pop();
 
     test(unitName + ':' + testNr++,
     function(assert) {
-      var f;
+      let f;
       assert.ok(typeof stub, 'object');
 
       //
@@ -101,7 +101,7 @@ helpers.unit = function(method, error) {
 function mockClient(code, path, extra) {
   return function(debug, error) {
     extra = extra || {};
-    var opts = _.extend(extra, {
+    const opts = _.extend(extra, {
       url: helpers.couch + path,
       log: debug,
       request: function(req, cb) {

--- a/tests/integration/attachment/destroy.js
+++ b/tests/integration/attachment/destroy.js
@@ -28,15 +28,15 @@ it('should be able to insert a new plain text attachment', function(assert) {
       assert.equal(error, null, 'delete the attachment');
       assert.equal(response.ok, true, 'response ok');
       assert.equal(response.id, 'new', '`id` should be `new`');
-      assert.end();
     });
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
-  p.then(function(docs) {
+  assert.ok(helpers.isPromise(p), 'returns Promise');
+  p.then(function(response) {
     assert.ok(true, 'Promise is resolved');
     assert.equal(response.ok, true, 'response ok');
     assert.equal(response.id, 'new', '`id` should be `new`');
-  }).catch(function(error) {
+    assert.end();
+  }).catch(function() {
     assert.ok(false, 'Promise is rejected');
   });
 });
@@ -44,12 +44,12 @@ it('should be able to insert a new plain text attachment', function(assert) {
 it('should fail destroying with a bad filename', function(assert) {
   var p = db.attachment.destroy('new', false, true, function(error, response) {
     assert.equal(response, undefined, 'no response should be given');
-    assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
-  p.then(function(docs) {
+  assert.ok(helpers.isPromise(p), 'returns Promise');
+  p.then(function() {
     assert.ok(false, 'Promise is resolved');
-  }).catch(function(error) {
+  }).catch(function() {
     assert.ok(true, 'Promise is rejected');
+    assert.end();
   });
 });

--- a/tests/integration/attachment/destroy.js
+++ b/tests/integration/attachment/destroy.js
@@ -18,7 +18,7 @@ var it = harness.it;
 var db = harness.locals.db;
 
 it('should be able to insert a new plain text attachment', function(assert) {
-  db.attachment.insert('new',
+  var p = db.attachment.insert('new',
   'att', 'Hello World!', 'text/plain', function(error, att) {
     assert.equal(error, null, 'store the attachment');
     assert.equal(att.ok, true, 'response ok');
@@ -31,11 +31,25 @@ it('should be able to insert a new plain text attachment', function(assert) {
       assert.end();
     });
   });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(docs) {
+    assert.ok(true, 'Promise is resolved');
+    assert.equal(response.ok, true, 'response ok');
+    assert.equal(response.id, 'new', '`id` should be `new`');
+  }).catch(function(error) {
+    assert.ok(false, 'Promise is rejected');
+  });
 });
 
 it('should fail destroying with a bad filename', function(assert) {
-  db.attachment.destroy('new', false, true, function(error, response) {
+  var p = db.attachment.destroy('new', false, true, function(error, response) {
     assert.equal(response, undefined, 'no response should be given');
     assert.end();
+  });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(docs) {
+    assert.ok(false, 'Promise is resolved');
+  }).catch(function(error) {
+    assert.ok(true, 'Promise is rejected');
   });
 });

--- a/tests/integration/attachment/destroy.js
+++ b/tests/integration/attachment/destroy.js
@@ -12,13 +12,13 @@
 
 'use strict';
 
-var helpers = require('../../helpers/integration');
-var harness = helpers.harness(__filename);
-var it = harness.it;
-var db = harness.locals.db;
+const helpers = require('../../helpers/integration');
+const harness = helpers.harness(__filename);
+const it = harness.it;
+const db = harness.locals.db;
 
 it('should be able to insert a new plain text attachment', function(assert) {
-  var p = db.attachment.insert('new',
+  const p = db.attachment.insert('new',
   'att', 'Hello World!', 'text/plain', function(error, att) {
     assert.equal(error, null, 'store the attachment');
     assert.equal(att.ok, true, 'response ok');
@@ -42,7 +42,7 @@ it('should be able to insert a new plain text attachment', function(assert) {
 });
 
 it('should fail destroying with a bad filename', function(assert) {
-  var p = db.attachment.destroy('new', false, true, function(error, response) {
+  const p = db.attachment.destroy('new', false, true, function(error, response) {
     assert.equal(response, undefined, 'no response should be given');
   });
   assert.ok(helpers.isPromise(p), 'returns Promise');

--- a/tests/integration/attachment/get.js
+++ b/tests/integration/attachment/get.js
@@ -23,11 +23,18 @@ it('should be able to fetch an attachment', function(assert) {
     assert.equal(error, null, 'should store `hello`');
     assert.equal(hello.ok, true, 'response ok');
     assert.ok(hello.rev, 'should have a revision number');
-    db.attachment.get('new_string', 'att',
+    var p = db.attachment.get('new_string', 'att',
     function(error, helloWorld) {
       assert.equal(error, null, 'should get `hello`');
       assert.equal('Hello', helloWorld.toString(), 'string is reflexive');
       assert.end();
+    });
+    assert.ok(helpers.isPromise(p), 'returns Promise')
+    p.then(function(s) {
+      assert.ok(true, 'Promise is resolved');
+      assert.equal('Hello', s.toString(), 'string is reflexive');
+    }).catch(function(error) {
+      assert.ok(false, 'Promise is rejected');
     });
   });
 });
@@ -38,11 +45,18 @@ it('should insert and fetch a binary file', function(assert) {
     assert.equal(error, null, 'should store `123`');
     assert.equal(hello.ok, true, 'response ok');
     assert.ok(hello.rev, 'should have a revision number');
-    db.attachment.get('new_binary', 'att',
+    var p = db.attachment.get('new_binary', 'att',
     function(error, binaryData) {
       assert.equal(error, null, 'should get the binary data');
       assert.equal('123', binaryData.toString(), 'binary data is reflexive');
       assert.end();
+    });
+    assert.ok(helpers.isPromise(p), 'returns Promise')
+    p.then(function(binaryData) {
+      assert.ok(true, 'Promise is resolved');
+      assert.equal('123', binaryData.toString(), 'binary data is reflexive');
+    }).catch(function(error) {
+      assert.ok(false, 'Promise is rejected');
     });
   });
 });

--- a/tests/integration/attachment/get.js
+++ b/tests/integration/attachment/get.js
@@ -12,10 +12,10 @@
 
 'use strict';
 
-var helpers = require('../../helpers/integration');
-var harness = helpers.harness(__filename);
-var it = harness.it;
-var db = harness.locals.db;
+const helpers = require('../../helpers/integration');
+const harness = helpers.harness(__filename);
+const it = harness.it;
+const db = harness.locals.db;
 
 it('should be able to fetch an attachment', function(assert) {
   db.attachment.insert('new_string', 'att', 'Hello', 'text/plain',
@@ -23,7 +23,7 @@ it('should be able to fetch an attachment', function(assert) {
     assert.equal(error, null, 'should store `hello`');
     assert.equal(hello.ok, true, 'response ok');
     assert.ok(hello.rev, 'should have a revision number');
-    var p = db.attachment.get('new_string', 'att',
+    const p = db.attachment.get('new_string', 'att',
     function(error, helloWorld) {
       assert.equal(error, null, 'should get `hello`');
       assert.equal('Hello', helloWorld.toString(), 'string is reflexive');
@@ -45,7 +45,7 @@ it('should insert and fetch a binary file', function(assert) {
     assert.equal(error, null, 'should store `123`');
     assert.equal(hello.ok, true, 'response ok');
     assert.ok(hello.rev, 'should have a revision number');
-    var p = db.attachment.get('new_binary', 'att',
+    const p = db.attachment.get('new_binary', 'att',
     function(error, binaryData) {
       assert.equal(error, null, 'should get the binary data');
       assert.equal('123', binaryData.toString(), 'binary data is reflexive');

--- a/tests/integration/attachment/get.js
+++ b/tests/integration/attachment/get.js
@@ -27,13 +27,13 @@ it('should be able to fetch an attachment', function(assert) {
     function(error, helloWorld) {
       assert.equal(error, null, 'should get `hello`');
       assert.equal('Hello', helloWorld.toString(), 'string is reflexive');
-      assert.end();
     });
-    assert.ok(helpers.isPromise(p), 'returns Promise')
+    assert.ok(helpers.isPromise(p), 'returns Promise');
     p.then(function(s) {
       assert.ok(true, 'Promise is resolved');
       assert.equal('Hello', s.toString(), 'string is reflexive');
-    }).catch(function(error) {
+      assert.end();
+    }).catch(function() {
       assert.ok(false, 'Promise is rejected');
     });
   });
@@ -49,13 +49,13 @@ it('should insert and fetch a binary file', function(assert) {
     function(error, binaryData) {
       assert.equal(error, null, 'should get the binary data');
       assert.equal('123', binaryData.toString(), 'binary data is reflexive');
-      assert.end();
     });
-    assert.ok(helpers.isPromise(p), 'returns Promise')
+    assert.ok(helpers.isPromise(p), 'returns Promise');
     p.then(function(binaryData) {
       assert.ok(true, 'Promise is resolved');
       assert.equal('123', binaryData.toString(), 'binary data is reflexive');
-    }).catch(function(error) {
+      assert.end();
+    }).catch(function() {
       assert.ok(false, 'Promise is rejected');
     });
   });

--- a/tests/integration/attachment/insert.js
+++ b/tests/integration/attachment/insert.js
@@ -23,14 +23,14 @@ it('should be able to insert a simple attachment', function(assert) {
     assert.equal(error, null, 'should store the attachment');
     assert.equal(att.ok, true, 'response ok');
     assert.ok(att.rev, 'should have a revision');
-    assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
-  p.then(function(docs) {
+  assert.ok(helpers.isPromise(p), 'returns Promise');
+  p.then(function(att) {
     assert.ok(true, 'Promise is resolved');
     assert.equal(att.ok, true, 'response ok');
     assert.ok(att.rev, 'should have a revision');
-  }).catch(function(error) {
+    assert.end();
+  }).catch(function() {
     assert.ok(false, 'Promise is rejected');
   });
 });

--- a/tests/integration/attachment/insert.js
+++ b/tests/integration/attachment/insert.js
@@ -12,13 +12,13 @@
 
 'use strict';
 
-var helpers = require('../../helpers/integration');
-var harness = helpers.harness(__filename);
-var it = harness.it;
-var db = harness.locals.db;
+const helpers = require('../../helpers/integration');
+const harness = helpers.harness(__filename);
+const it = harness.it;
+const db = harness.locals.db;
 
 it('should be able to insert a simple attachment', function(assert) {
-  var p = db.attachment.insert('new', 'att', 'Hello World!', 'text/plain',
+  const p = db.attachment.insert('new', 'att', 'Hello World!', 'text/plain',
   function(error, att) {
     assert.equal(error, null, 'should store the attachment');
     assert.equal(att.ok, true, 'response ok');

--- a/tests/integration/attachment/insert.js
+++ b/tests/integration/attachment/insert.js
@@ -18,11 +18,19 @@ var it = harness.it;
 var db = harness.locals.db;
 
 it('should be able to insert a simple attachment', function(assert) {
-  db.attachment.insert('new', 'att', 'Hello World!', 'text/plain',
+  var p = db.attachment.insert('new', 'att', 'Hello World!', 'text/plain',
   function(error, att) {
     assert.equal(error, null, 'should store the attachment');
     assert.equal(att.ok, true, 'response ok');
     assert.ok(att.rev, 'should have a revision');
     assert.end();
+  });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(docs) {
+    assert.ok(true, 'Promise is resolved');
+    assert.equal(att.ok, true, 'response ok');
+    assert.ok(att.rev, 'should have a revision');
+  }).catch(function(error) {
+    assert.ok(false, 'Promise is rejected');
   });
 });

--- a/tests/integration/attachment/pipe.js
+++ b/tests/integration/attachment/pipe.js
@@ -34,14 +34,14 @@ it('should be able to pipe to a writeStream', function(assert) {
   db.attachment.insert('new', 'att', buffer, 'image/bmp',
   function(error, bmp) {
     assert.equal(error, null, 'Should store the pixel');
-    db.attachment.get('new', 'att', {rev: bmp.rev}).pipe(ws);
+    db.attachment.getAsStream('new', 'att', {rev: bmp.rev}).pipe(ws);
   });
 });
 
 it('should be able to pipe from a readStream', function(assert) {
   var logo = path.join(__dirname, '..', '..', 'fixtures', 'logo.png');
   var rs = fs.createReadStream(logo);
-  var is = db.attachment.insert('nodejs', 'logo.png', null, 'image/png');
+  var is = db.attachment.insertAsStream('nodejs', 'logo.png', null, 'image/png');
 
   is.on('end', function() {
     db.attachment.get('nodejs', 'logo.png', function(err, buffer) {

--- a/tests/integration/attachment/pipe.js
+++ b/tests/integration/attachment/pipe.js
@@ -38,10 +38,20 @@ it('should be able to pipe to a writeStream', function(assert) {
   });
 });
 
+it('should be able to pipe to a writeStream', function(assert) {
+  var ws = fs.createWriteStream('/dev/null');
+  db.attachment.getAsStream('new', 'att', function() {})
+    .pipe(ws)
+    .on('end', function() {
+      assert.end();
+    });
+});
+
 it('should be able to pipe from a readStream', function(assert) {
   var logo = path.join(__dirname, '..', '..', 'fixtures', 'logo.png');
   var rs = fs.createReadStream(logo);
-  var is = db.attachment.insertAsStream('nodejs', 'logo.png', null, 'image/png');
+  var is = db.attachment.insertAsStream('nodejs', 'logo.png', null, 'image/png', function() {
+  });
 
   is.on('end', function() {
     db.attachment.get('nodejs', 'logo.png', function(err, buffer) {

--- a/tests/integration/attachment/pipe.js
+++ b/tests/integration/attachment/pipe.js
@@ -12,18 +12,18 @@
 
 'use strict';
 
-var fs = require('fs');
-var path = require('path');
-var helpers = require('../../helpers/integration');
-var harness = helpers.harness(__filename);
-var db = harness.locals.db;
-var it = harness.it;
-var pixel = helpers.pixel;
+const fs = require('fs');
+const path = require('path');
+const helpers = require('../../helpers/integration');
+const harness = helpers.harness(__filename);
+const db = harness.locals.db;
+const it = harness.it;
+const pixel = helpers.pixel;
 
 it('should be able to pipe to a writeStream', function(assert) {
-  var buffer = new Buffer(pixel, 'base64');
-  var filename = path.join(__dirname, '.temp.bmp');
-  var ws = fs.createWriteStream(filename);
+  const buffer = new Buffer(pixel, 'base64');
+  const filename = path.join(__dirname, '.temp.bmp');
+  const ws = fs.createWriteStream(filename);
 
   ws.on('close', function() {
     assert.equal(fs.readFileSync(filename).toString('base64'), pixel);
@@ -39,7 +39,7 @@ it('should be able to pipe to a writeStream', function(assert) {
 });
 
 it('should be able to pipe to a writeStream', function(assert) {
-  var ws = fs.createWriteStream('/dev/null');
+  const ws = fs.createWriteStream('/dev/null');
   db.attachment.getAsStream('new', 'att', function() {})
     .pipe(ws)
     .on('end', function() {
@@ -48,9 +48,9 @@ it('should be able to pipe to a writeStream', function(assert) {
 });
 
 it('should be able to pipe from a readStream', function(assert) {
-  var logo = path.join(__dirname, '..', '..', 'fixtures', 'logo.png');
-  var rs = fs.createReadStream(logo);
-  var is = db.attachment.insertAsStream('nodejs', 'logo.png', null, 'image/png', function() {
+  const logo = path.join(__dirname, '..', '..', 'fixtures', 'logo.png');
+  const rs = fs.createReadStream(logo);
+  const is = db.attachment.insertAsStream('nodejs', 'logo.png', null, 'image/png', function() {
   });
 
   is.on('end', function() {

--- a/tests/integration/attachment/update.js
+++ b/tests/integration/attachment/update.js
@@ -27,12 +27,19 @@ it('should be able to insert and update attachments', function(assert) {
     assert.equal(error, null, 'should store hello');
     assert.equal(hello.ok, true, 'response ok');
     assert.ok(hello.rev, 'should have a revision');
-    db.attachment.insert('new', 'att', buffer, 'image/bmp',
+    var p = db.attachment.insert('new', 'att', buffer, 'image/bmp',
     {rev: hello.rev}, function(error, bmp) {
       assert.equal(error, null, 'should store the pixel');
       assert.ok(bmp.rev, 'should store a revision');
       rev = bmp.rev;
       assert.end();
+    });
+    assert.ok(helpers.isPromise(p), 'returns Promise')
+    p.then(function(s) {
+      assert.ok(true, 'Promise is resolved');
+      assert.ok(s.rev, 'should store a revision');
+    }).catch(function(error) {
+      assert.ok(false, 'Promise is rejected');
     });
   });
 });

--- a/tests/integration/attachment/update.js
+++ b/tests/integration/attachment/update.js
@@ -12,21 +12,22 @@
 
 'use strict';
 
-var helpers = require('../../helpers/integration');
-var pixel = helpers.pixel;
-var harness = helpers.harness(__filename);
-var db = harness.locals.db;
-var it = harness.it;
-var rev;
+const helpers = require('../../helpers/integration');
+const pixel = helpers.pixel;
+const harness = helpers.harness(__filename);
+const db = harness.locals.db;
+const it = harness.it;
+
+let rev;
 
 it('should be able to insert and update attachments', function(assert) {
-  var buffer = new Buffer(pixel, 'base64');
+  const buffer = new Buffer(pixel, 'base64');
   db.attachment.insert('new', 'att', 'Hello', 'text/plain',
   function(error, hello) {
     assert.equal(error, null, 'should store hello');
     assert.equal(hello.ok, true, 'response ok');
     assert.ok(hello.rev, 'should have a revision');
-    var p = db.attachment.insert('new', 'att', buffer, 'image/bmp',
+    const p = db.attachment.insert('new', 'att', buffer, 'image/bmp',
     {rev: hello.rev}, function(error, bmp) {
       assert.equal(error, null, 'should store the pixel');
       assert.ok(bmp.rev, 'should store a revision');

--- a/tests/integration/attachment/update.js
+++ b/tests/integration/attachment/update.js
@@ -17,7 +17,6 @@ var pixel = helpers.pixel;
 var harness = helpers.harness(__filename);
 var db = harness.locals.db;
 var it = harness.it;
-
 var rev;
 
 it('should be able to insert and update attachments', function(assert) {
@@ -32,13 +31,13 @@ it('should be able to insert and update attachments', function(assert) {
       assert.equal(error, null, 'should store the pixel');
       assert.ok(bmp.rev, 'should store a revision');
       rev = bmp.rev;
-      assert.end();
     });
-    assert.ok(helpers.isPromise(p), 'returns Promise')
+    assert.ok(helpers.isPromise(p), 'returns Promise');
     p.then(function(s) {
       assert.ok(true, 'Promise is resolved');
       assert.ok(s.rev, 'should store a revision');
-    }).catch(function(error) {
+      assert.end();
+    }).catch(function() {
       assert.ok(false, 'Promise is rejected');
     });
   });

--- a/tests/integration/database/changes.js
+++ b/tests/integration/database/changes.js
@@ -20,9 +20,16 @@ var it = harness.it;
 it('should be able to insert three documents', helpers.insertThree);
 
 it('should be able to receive changes since seq:0', function(assert) {
-  db.changes({since:0}, function(error, response) {
+  var p = db.changes({since:0}, function(error, response) {
     assert.equal(error, null, 'gets response from changes');
     assert.equal(response.results.length, 3, 'gets three results');
     assert.end();
+  });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(response) {
+    assert.ok(true, 'Promise is resolved');
+    assert.equal(response.results.length, 3, 'gets three results');
+  }).catch(function(error) {
+    assert.ok(false, 'Promise is rejected');
   });
 });

--- a/tests/integration/database/changes.js
+++ b/tests/integration/database/changes.js
@@ -23,13 +23,13 @@ it('should be able to receive changes since seq:0', function(assert) {
   var p = db.changes({since:0}, function(error, response) {
     assert.equal(error, null, 'gets response from changes');
     assert.equal(response.results.length, 3, 'gets three results');
-    assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
+  assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(response) {
     assert.ok(true, 'Promise is resolved');
     assert.equal(response.results.length, 3, 'gets three results');
-  }).catch(function(error) {
+    assert.end();
+  }).catch(function() {
     assert.ok(false, 'Promise is rejected');
   });
 });

--- a/tests/integration/database/changes.js
+++ b/tests/integration/database/changes.js
@@ -12,15 +12,15 @@
 
 'use strict';
 
-var helpers = require('../../helpers/integration');
-var harness = helpers.harness(__filename);
-var db = harness.locals.db;
-var it = harness.it;
+const helpers = require('../../helpers/integration');
+const harness = helpers.harness(__filename);
+const db = harness.locals.db;
+const it = harness.it;
 
 it('should be able to insert three documents', helpers.insertThree);
 
 it('should be able to receive changes since seq:0', function(assert) {
-  var p = db.changes({since:0}, function(error, response) {
+  const p = db.changes({since:0}, function(error, response) {
     assert.equal(error, null, 'gets response from changes');
     assert.equal(response.results.length, 3, 'gets three results');
   });
@@ -35,7 +35,7 @@ it('should be able to receive changes since seq:0', function(assert) {
 });
 
 it('should be able to receive changes since seq:0 as stream', function(assert) {
-  var p = db.changesAsStream({since:0}, function(error, response) {
+  const p = db.changesAsStream({since:0}, function(error, response) {
     assert.equal(error, null, 'gets response from changes');
     assert.equal(response.results.length, 3, 'gets three results');
     assert.end();
@@ -45,7 +45,7 @@ it('should be able to receive changes since seq:0 as stream', function(assert) {
 });
 
 it('should be able to receive changes - no params - stream', function(assert) {
-  var p = db.changesAsStream(function(error) {
+  const p = db.changesAsStream(function(error) {
     assert.equal(error, null, 'gets response from changes');
     assert.end();
   });

--- a/tests/integration/database/changes.js
+++ b/tests/integration/database/changes.js
@@ -33,3 +33,13 @@ it('should be able to receive changes since seq:0', function(assert) {
     assert.ok(false, 'Promise is rejected');
   });
 });
+
+it('should be able to receive changes since seq:0 as stream', function(assert) {
+  var p = db.changesAsStream({since:0}, function(error, response) {
+    assert.equal(error, null, 'gets response from changes');
+    assert.equal(response.results.length, 3, 'gets three results');
+    assert.end();
+  });
+  assert.ok(!helpers.isPromise(p), 'returns Promise');
+  assert.equal(p.constructor.name, 'Request', 'returns a Request');
+});

--- a/tests/integration/database/changes.js
+++ b/tests/integration/database/changes.js
@@ -43,3 +43,12 @@ it('should be able to receive changes since seq:0 as stream', function(assert) {
   assert.ok(!helpers.isPromise(p), 'returns Promise');
   assert.equal(p.constructor.name, 'Request', 'returns a Request');
 });
+
+it('should be able to receive changes - no params - stream', function(assert) {
+  var p = db.changesAsStream(function(error) {
+    assert.equal(error, null, 'gets response from changes');
+    assert.end();
+  });
+  assert.ok(!helpers.isPromise(p), 'returns Promise');
+  assert.equal(p.constructor.name, 'Request', 'returns a Request');
+});

--- a/tests/integration/database/compact.js
+++ b/tests/integration/database/compact.js
@@ -36,15 +36,15 @@ it('should have run the compaction', function(assert) {
       assert.equal(error, null, 'info should respond');
       assert.equal(info['doc_count'], 0, 'document count is not 3');
       assert.equal(info['doc_del_count'], 1, 'document should be deleted');
-      assert.end();
     });
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
-  p.then(function(response) {
+  assert.ok(helpers.isPromise(p), 'returns Promise');
+  p.then(function(info) {
     assert.ok(true, 'Promise is resolved');
     assert.equal(info['doc_count'], 0, 'document count is not 3');
     assert.equal(info['doc_del_count'], 1, 'document should be deleted');
-  }).catch(function(error) {
+    assert.end();
+  }).catch(function() {
     assert.ok(false, 'Promise is rejected');
   });
 });

--- a/tests/integration/database/compact.js
+++ b/tests/integration/database/compact.js
@@ -12,10 +12,10 @@
 
 'use strict';
 
-var helpers = require('../../helpers/integration');
-var harness = helpers.harness(__filename);
-var it = harness.it;
-var db = harness.locals.db;
+const helpers = require('../../helpers/integration');
+const harness = helpers.harness(__filename);
+const it = harness.it;
+const db = harness.locals.db;
 
 it('should store and delete `goofy`', function(assert) {
   db.insert({'foo': 'baz'}, 'goofy', function(error, foo) {
@@ -30,7 +30,7 @@ it('should store and delete `goofy`', function(assert) {
 });
 
 it('should have run the compaction', function(assert) {
-  var p = db.compact(function(error) {
+  const p = db.compact(function(error) {
     assert.equal(error, null, 'compact should respond');
     db.info(function(error, info) {
       assert.equal(error, null, 'info should respond');
@@ -64,5 +64,5 @@ it('should finish compaction before ending', function(assert) {
     });
   }
 
-  var task = setInterval(nextWhenFinished, 100);
+  const task = setInterval(nextWhenFinished, 100);
 });

--- a/tests/integration/database/compact.js
+++ b/tests/integration/database/compact.js
@@ -30,7 +30,7 @@ it('should store and delete `goofy`', function(assert) {
 });
 
 it('should have run the compaction', function(assert) {
-  db.compact(function(error) {
+  var p = db.compact(function(error) {
     assert.equal(error, null, 'compact should respond');
     db.info(function(error, info) {
       assert.equal(error, null, 'info should respond');
@@ -38,6 +38,14 @@ it('should have run the compaction', function(assert) {
       assert.equal(info['doc_del_count'], 1, 'document should be deleted');
       assert.end();
     });
+  });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(response) {
+    assert.ok(true, 'Promise is resolved');
+    assert.equal(info['doc_count'], 0, 'document count is not 3');
+    assert.equal(info['doc_del_count'], 1, 'document should be deleted');
+  }).catch(function(error) {
+    assert.ok(false, 'Promise is rejected');
   });
 });
 

--- a/tests/integration/database/create-and-destroy.js
+++ b/tests/integration/database/create-and-destroy.js
@@ -12,11 +12,11 @@
 
 'use strict';
 
-var async = require('async');
-var helpers = require('../../helpers/integration');
-var harness = helpers.harness(__filename);
-var it = harness.it;
-var nano = harness.locals.nano;
+const async = require('async');
+const helpers = require('../../helpers/integration');
+const harness = helpers.harness(__filename);
+const it = harness.it;
+const nano = harness.locals.nano;
 
 it('should be able to create `az09_$()+-/` database', function(assert) {
   nano.db.create('az09_$()+-/', function(err) {
@@ -27,7 +27,7 @@ it('should be able to create `az09_$()+-/` database', function(assert) {
 
 it('should be able to use config from a nano object to create a db',
 function(assert) {
-  var config = helpers.Nano(
+  const config = helpers.Nano(
     helpers.couch + '/' + encodeURIComponent('with/slash')).config;
   helpers.Nano(config.url).db.create(config.db, function(err) {
     assert.equal(err, null, 'should create database');

--- a/tests/integration/database/follow.js
+++ b/tests/integration/database/follow.js
@@ -12,18 +12,18 @@
 
 'use strict';
 
-var helpers = require('../../helpers/integration');
-var harness = helpers.harness(__filename);
-var it = harness.it;
-var db = harness.locals.db;
+const helpers = require('../../helpers/integration');
+const harness = helpers.harness(__filename);
+const it = harness.it;
+const db = harness.locals.db;
 
 if (helpers.unmocked) {
   it('should insert a bunch of items', helpers.insertThree);
 
-  var feed1;
+  let feed1;
 
   it('should be able to get the changes feed', function(assert) {
-    var i = 3;
+    let i = 3;
 
     feed1 = db.follow({since: '0'});
 

--- a/tests/integration/database/get.js
+++ b/tests/integration/database/get.js
@@ -22,14 +22,14 @@ it('should be able to fetch the database', function(assert) {
     assert.equal(error, null, 'should get the db');
     assert.equal(response['doc_count'], 0, 'should be empty');
     assert.equal(response['db_name'], 'database_get', 'name');
-    assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
-  p.then(function(docs) {
+  assert.ok(helpers.isPromise(p), 'returns Promise');
+  p.then(function(response) {
     assert.ok(true, 'Promise is resolved');
     assert.equal(response['doc_count'], 0, 'should be empty');
     assert.equal(response['db_name'], 'database_get', 'name');
-  }).catch(function(error) {
+    assert.end();
+  }).catch(function() {
     assert.ok(false, 'Promise is rejected');
   });
 });

--- a/tests/integration/database/get.js
+++ b/tests/integration/database/get.js
@@ -18,11 +18,19 @@ var it = harness.it;
 var nano = harness.locals.nano;
 
 it('should be able to fetch the database', function(assert) {
-  nano.db.get('database_get', function(error, response) {
+  var p = nano.db.get('database_get', function(error, response) {
     assert.equal(error, null, 'should get the db');
     assert.equal(response['doc_count'], 0, 'should be empty');
     assert.equal(response['db_name'], 'database_get', 'name');
     assert.end();
+  });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(docs) {
+    assert.ok(true, 'Promise is resolved');
+    assert.equal(response['doc_count'], 0, 'should be empty');
+    assert.equal(response['db_name'], 'database_get', 'name');
+  }).catch(function(error) {
+    assert.ok(false, 'Promise is rejected');
   });
 });
 

--- a/tests/integration/database/get.js
+++ b/tests/integration/database/get.js
@@ -12,13 +12,13 @@
 
 'use strict';
 
-var helpers = require('../../helpers/integration');
-var harness = helpers.harness(__filename);
-var it = harness.it;
-var nano = harness.locals.nano;
+const helpers = require('../../helpers/integration');
+const harness = helpers.harness(__filename);
+const it = harness.it;
+const nano = harness.locals.nano;
 
 it('should be able to fetch the database', function(assert) {
-  var p = nano.db.get('database_get', function(error, response) {
+  const p = nano.db.get('database_get', function(error, response) {
     assert.equal(error, null, 'should get the db');
     assert.equal(response['doc_count'], 0, 'should be empty');
     assert.equal(response['db_name'], 'database_get', 'name');
@@ -35,9 +35,9 @@ it('should be able to fetch the database', function(assert) {
 });
 
 it('resolves db URL correctly for http://app.com/_couchdb', function(assert) {
-  var nano = require('../../../lib/nano');
+  const nano = require('../../../lib/nano');
 
-  var couch = nano({
+  const couch = nano({
     url: 'http://app.com/_couchdb/',
     parseUrl: false,
     request: function(options) {

--- a/tests/integration/database/list.js
+++ b/tests/integration/database/list.js
@@ -28,12 +28,19 @@ it('should ensure _replicator and _users are created', function(assert) {
 });
 
 it('should list the correct databases', function(assert) {
-  nano.db.list(function(error, list) {
+  var p = nano.db.list(function(error, list) {
     assert.equal(error, null, 'should list databases');
     var filtered = list.filter(function(e) {
       return e === 'database_list' || e === '_replicator' || e === '_users';
     });
     assert.equal(filtered.length, 3, 'should have exactly 3 dbs');
     assert.end();
+  });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(list) {
+    assert.ok(true, 'Promise is resolved');
+    assert.equal(filtered.length, 3, 'should have exactly 3 dbs');
+  }).catch(function(error) {
+    assert.ok(false, 'Promise is rejected');
   });
 });

--- a/tests/integration/database/list.js
+++ b/tests/integration/database/list.js
@@ -12,10 +12,10 @@
 
 'use strict';
 
-var helpers = require('../../helpers/integration');
-var harness = helpers.harness(__filename);
-var it = harness.it;
-var nano = harness.locals.nano;
+const helpers = require('../../helpers/integration');
+const harness = helpers.harness(__filename);
+const it = harness.it;
+const nano = harness.locals.nano;
 
 it('should ensure _replicator and _users are created', function(assert) {
   nano.db.create('_replicator', function() {
@@ -28,9 +28,9 @@ it('should ensure _replicator and _users are created', function(assert) {
 });
 
 it('should list the correct databases', function(assert) {
-  var p = nano.db.list(function(error, list) {
+  const p = nano.db.list(function(error, list) {
     assert.equal(error, null, 'should list databases');
-    var filtered = list.filter(function(e) {
+    const filtered = list.filter(function(e) {
       return e === 'database_list' || e === '_replicator' || e === '_users';
     });
     assert.equal(filtered.length, 3, 'should have exactly 3 dbs');

--- a/tests/integration/database/list.js
+++ b/tests/integration/database/list.js
@@ -34,13 +34,12 @@ it('should list the correct databases', function(assert) {
       return e === 'database_list' || e === '_replicator' || e === '_users';
     });
     assert.equal(filtered.length, 3, 'should have exactly 3 dbs');
-    assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
-  p.then(function(list) {
+  assert.ok(helpers.isPromise(p), 'returns Promise');
+  p.then(function() {
     assert.ok(true, 'Promise is resolved');
-    assert.equal(filtered.length, 3, 'should have exactly 3 dbs');
-  }).catch(function(error) {
+    assert.end();
+  }).catch(function() {
     assert.ok(false, 'Promise is rejected');
   });
 });

--- a/tests/integration/database/replicate.js
+++ b/tests/integration/database/replicate.js
@@ -35,13 +35,20 @@ it('creates a bunch of database replicas', function(assert) {
 it('should be able to replicate three docs', function(assert) {
   replica = nano.use('database_replica');
 
-  db.replicate('database_replica', function(error) {
+  var p = db.replicate('database_replica', function(error) {
     assert.equal(error, null, 'replication should work');
     replica.list(function(error, list) {
       assert.equal(error, null, 'should be able to invoke list');
       assert.equal(list['total_rows'], 3, 'and have three documents');
       assert.end();
     });
+  });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(list) {
+    assert.ok(true, 'Promise is resolved');
+    assert.equal(list['total_rows'], 3, 'and have three documents');
+  }).catch(function(error) {
+    assert.ok(false, 'Promise is rejected');
   });
 });
 
@@ -59,9 +66,15 @@ it('should be able to replicate to a `nano` object', function(assert) {
 });
 
 it('should be able to replicate with params', function(assert) {
-  db.replicate('database_replica', {}, function(error) {
+  var p = db.replicate('database_replica', {}, function(error) {
     assert.equal(error, null, 'replication should work');
     assert.end();
+  });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(list) {
+    assert.ok(true, 'Promise is resolved');
+  }).catch(function(error) {
+    assert.ok(false, 'Promise is rejected');
   });
 });
 

--- a/tests/integration/database/replicate.js
+++ b/tests/integration/database/replicate.js
@@ -12,15 +12,15 @@
 
 'use strict';
 
-var async = require('async');
-var helpers = require('../../helpers/integration');
-var harness = helpers.harness(__filename);
-var it = harness.it;
-var db = harness.locals.db;
-var nano = harness.locals.nano;
+const async = require('async');
+const helpers = require('../../helpers/integration');
+const harness = helpers.harness(__filename);
+const it = harness.it;
+const db = harness.locals.db;
+const nano = harness.locals.nano;
 
-var replica;
-var replica2;
+let replica;
+let replica2;
 
 it('should insert a bunch of items', helpers.insertThree);
 
@@ -35,7 +35,7 @@ it('creates a bunch of database replicas', function(assert) {
 it('should be able to replicate three docs', function(assert) {
   replica = nano.use('database_replica');
 
-  var p = db.replicate('database_replica', function(error) {
+  const p = db.replicate('database_replica', function(error) {
     assert.equal(error, null, 'replication should work');
     replica.list(function(error, list) {
       assert.equal(error, null, 'should be able to invoke list');
@@ -66,7 +66,7 @@ it('should be able to replicate to a `nano` object', function(assert) {
 });
 
 it('should be able to replicate with params', function(assert) {
-  var p = db.replicate('database_replica', {}, function(error) {
+  const p = db.replicate('database_replica', {}, function(error) {
     assert.equal(error, null, 'replication should work');
   });
   assert.ok(helpers.isPromise(p), 'returns Promise');

--- a/tests/integration/database/replicate.js
+++ b/tests/integration/database/replicate.js
@@ -40,14 +40,14 @@ it('should be able to replicate three docs', function(assert) {
     replica.list(function(error, list) {
       assert.equal(error, null, 'should be able to invoke list');
       assert.equal(list['total_rows'], 3, 'and have three documents');
-      assert.end();
     });
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
+  assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(list) {
     assert.ok(true, 'Promise is resolved');
     assert.equal(list['total_rows'], 3, 'and have three documents');
-  }).catch(function(error) {
+    assert.end();
+  }).catch(function() {
     assert.ok(false, 'Promise is rejected');
   });
 });
@@ -68,12 +68,12 @@ it('should be able to replicate to a `nano` object', function(assert) {
 it('should be able to replicate with params', function(assert) {
   var p = db.replicate('database_replica', {}, function(error) {
     assert.equal(error, null, 'replication should work');
-    assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
-  p.then(function(list) {
+  assert.ok(helpers.isPromise(p), 'returns Promise');
+  p.then(function() {
     assert.ok(true, 'Promise is resolved');
-  }).catch(function(error) {
+    assert.end();
+  }).catch(function() {
     assert.ok(false, 'Promise is rejected');
   });
 });

--- a/tests/integration/database/replicator.js
+++ b/tests/integration/database/replicator.js
@@ -53,11 +53,11 @@ it('should be able to replicate (replicator) three docs', function(assert) {
               assert.true(disabled.ok, 'should have stopped the replication');
               assert.end();
             });
-          })
-        })
+          });
+        });
       },
-      3000)
-    };
+      3000);
+    }
     waitForReplication();
   });
 });
@@ -83,10 +83,10 @@ it('should be able to replicate (replicator) to a `nano` object', function(asser
               assert.end();
             });
           });
-        })
+        });
       },
-      3000)
-    };
+      3000);
+    }
     waitForReplication();
   });
 });
@@ -112,10 +112,10 @@ it('should be able to replicate (replicator) with params', function(assert) {
               assert.end();
             });
           });
-        })
+        });
       },
-      3000)
-    };
+      3000);
+    }
     waitForReplication();
   });
 });

--- a/tests/integration/database/replicator.js
+++ b/tests/integration/database/replicator.js
@@ -12,16 +12,16 @@
 
 'use strict';
 
-var async = require('async');
-var helpers = require('../../helpers/integration');
-var harness = helpers.harness(__filename);
-var it = harness.it;
-var db = harness.locals.db;
-var nano = harness.locals.nano;
+const async = require('async');
+const helpers = require('../../helpers/integration');
+const harness = helpers.harness(__filename);
+const it = harness.it;
+const db = harness.locals.db;
+const nano = harness.locals.nano;
 
-var replica;
-var replica2;
-var replica3;
+let replica;
+let replica2;
+let replica3;
 
 it('should insert a bunch of items', helpers.insertThree);
 

--- a/tests/integration/design/atomic.js
+++ b/tests/integration/design/atomic.js
@@ -12,18 +12,18 @@
 
 'use strict';
 
-var helpers = require('../../helpers/integration');
-var harness = helpers.harness(__filename);
-var it = harness.it;
-var db = harness.locals.db;
+const helpers = require('../../helpers/integration');
+const harness = helpers.harness(__filename);
+const it = harness.it;
+const db = harness.locals.db;
 
-var rev;
+let rev;
 
 it('should be able to insert an atomic design doc', function(assert) {
-  var p = db.insert({
+  const p = db.insert({
     updates: {
       inplace: function(doc, req) {
-        var body = JSON.parse(req.body);
+        const body = JSON.parse(req.body);
         doc[body.field] = body.value;
         return [doc, JSON.stringify(doc)];
       },
@@ -46,7 +46,7 @@ it('should be able to insert an atomic design doc', function(assert) {
 });
 
 it('should be able to insert atomically', function(assert) {
-  var p = db.atomic('update', 'inplace', 'foobar', {
+  const p = db.atomic('update', 'inplace', 'foobar', {
     field: 'foo',
     value: 'bar'
   }, function(error, response) {
@@ -58,7 +58,7 @@ it('should be able to insert atomically', function(assert) {
 });
 
 it('should be able to update atomically without a body', function (assert) {
-  var p = db.insert({}, 'baz', function () {
+  const p = db.insert({}, 'baz', function () {
     db.atomic('update', 'addbaz', 'baz', function (error, response) {
       assert.equal(error, null, 'should be able to update');
       assert.equal(response.baz, 'biz', 'and the new field is present');
@@ -69,7 +69,7 @@ it('should be able to update atomically without a body', function (assert) {
 });
 
 it('should be able to update with slashes on the id', function(assert) {
-  var p = db.insert({'wat': 'wat'}, 'wat/wat', function(error, foo) {
+  const p = db.insert({'wat': 'wat'}, 'wat/wat', function(error, foo) {
     assert.equal(error, null, 'stores `wat`');
     assert.equal(foo.ok, true, 'response ok');
     db.atomic('update', 'inplace', 'wat/wat', {

--- a/tests/integration/design/atomic.js
+++ b/tests/integration/design/atomic.js
@@ -20,7 +20,7 @@ var db = harness.locals.db;
 var rev;
 
 it('should be able to insert an atomic design doc', function(assert) {
-  db.insert({
+  var p = db.insert({
     updates: {
       inplace: function(doc, req) {
         var body = JSON.parse(req.body);
@@ -42,10 +42,16 @@ it('should be able to insert an atomic design doc', function(assert) {
       assert.end();
     });
   });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(response) {
+    assert.ok(true, 'Promise is resolved');
+  }).catch(function(error) {
+    assert.ok(false, 'Promise is rejected');
+  });
 });
 
 it('should be able to insert atomically', function(assert) {
-  db.atomic('update', 'inplace', 'foobar', {
+  var p = db.atomic('update', 'inplace', 'foobar', {
     field: 'foo',
     value: 'bar'
   }, function(error, response) {
@@ -53,20 +59,34 @@ it('should be able to insert atomically', function(assert) {
     assert.equal(response.foo, 'bar', 'and the right value was set');
     assert.end();
   });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(response) {
+    assert.ok(true, 'Promise is resolved');
+    assert.equal(response.foo, 'bar', 'and the right value was set');
+  }).catch(function(error) {
+    assert.ok(false, 'Promise is rejected');
+  });
 });
 
 it('should be able to update atomically without a body', function (assert) {
-  db.insert({}, 'baz', function (error, doc) {
+  var p = db.insert({}, 'baz', function (error, doc) {
     db.atomic('update', 'addbaz', 'baz', function (error, response) {
       assert.equal(error, null, 'should be able to update');
       assert.equal(response.baz, 'biz', 'and the new field is present');
       assert.end();
     });
   });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(response) {
+    assert.ok(true, 'Promise is resolved');
+    assert.equal(response.baz, 'biz', 'and the new field is present');
+  }).catch(function(error) {
+    assert.ok(false, 'Promise is rejected');
+  });
 });
 
 it('should be able to update with slashes on the id', function(assert) {
-  db.insert({'wat': 'wat'}, 'wat/wat', function(error, foo) {
+  var p = db.insert({'wat': 'wat'}, 'wat/wat', function(error, foo) {
     assert.equal(error, null, 'stores `wat`');
     assert.equal(foo.ok, true, 'response ok');
     db.atomic('update', 'inplace', 'wat/wat', {
@@ -77,5 +97,12 @@ it('should be able to update with slashes on the id', function(assert) {
       assert.equal(response.wat, 'dawg', 'with the right copy');
       assert.end();
     });
+  });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(response) {
+    assert.ok(true, 'Promise is resolved');
+    assert.equal(response.wat, 'dawg', 'with the right copy');
+  }).catch(function(error) {
+    assert.ok(false, 'Promise is rejected');
   });
 });

--- a/tests/integration/design/atomic.js
+++ b/tests/integration/design/atomic.js
@@ -27,7 +27,7 @@ it('should be able to insert an atomic design doc', function(assert) {
         doc[body.field] = body.value;
         return [doc, JSON.stringify(doc)];
       },
-      addbaz: function (doc, req) {
+      addbaz: function (doc) {
         doc.baz = "biz";
         return [doc, JSON.stringify(doc)];
       }
@@ -42,12 +42,7 @@ it('should be able to insert an atomic design doc', function(assert) {
       assert.end();
     });
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
-  p.then(function(response) {
-    assert.ok(true, 'Promise is resolved');
-  }).catch(function(error) {
-    assert.ok(false, 'Promise is rejected');
-  });
+  assert.ok(helpers.isPromise(p), 'returns Promise');
 });
 
 it('should be able to insert atomically', function(assert) {
@@ -59,30 +54,18 @@ it('should be able to insert atomically', function(assert) {
     assert.equal(response.foo, 'bar', 'and the right value was set');
     assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
-  p.then(function(response) {
-    assert.ok(true, 'Promise is resolved');
-    assert.equal(response.foo, 'bar', 'and the right value was set');
-  }).catch(function(error) {
-    assert.ok(false, 'Promise is rejected');
-  });
+  assert.ok(helpers.isPromise(p), 'returns Promise');
 });
 
 it('should be able to update atomically without a body', function (assert) {
-  var p = db.insert({}, 'baz', function (error, doc) {
+  var p = db.insert({}, 'baz', function () {
     db.atomic('update', 'addbaz', 'baz', function (error, response) {
       assert.equal(error, null, 'should be able to update');
       assert.equal(response.baz, 'biz', 'and the new field is present');
       assert.end();
     });
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
-  p.then(function(response) {
-    assert.ok(true, 'Promise is resolved');
-    assert.equal(response.baz, 'biz', 'and the new field is present');
-  }).catch(function(error) {
-    assert.ok(false, 'Promise is rejected');
-  });
+  assert.ok(helpers.isPromise(p), 'returns Promise');
 });
 
 it('should be able to update with slashes on the id', function(assert) {
@@ -98,11 +81,5 @@ it('should be able to update with slashes on the id', function(assert) {
       assert.end();
     });
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
-  p.then(function(response) {
-    assert.ok(true, 'Promise is resolved');
-    assert.equal(response.wat, 'dawg', 'with the right copy');
-  }).catch(function(error) {
-    assert.ok(false, 'Promise is rejected');
-  });
+  assert.ok(helpers.isPromise(p), 'returns Promise');
 });

--- a/tests/integration/design/compact.js
+++ b/tests/integration/design/compact.js
@@ -12,11 +12,11 @@
 
 'use strict';
 
-var async = require('async');
-var helpers = require('../../helpers/integration');
-var harness = helpers.harness(__filename);
-var it = harness.it;
-var db = harness.locals.db;
+const async = require('async');
+const helpers = require('../../helpers/integration');
+const harness = helpers.harness(__filename);
+const it = harness.it;
+const db = harness.locals.db;
 
 it('should insert `alice` the design doc', function(assert) {
   async.waterfall([
@@ -40,29 +40,3 @@ it('should insert `alice` the design doc', function(assert) {
     assert.end();
   });
 });
-
-/*it('should be able to compact a view', function(assert) {
-  async.waterfall([
-    function(next) {
-      db.view.compact('alice', next);
-    },
-    function(response, _, next) {
-      function dbInfo() {
-        db.info(function(err, info) {
-          if (!info['compact_running']) {
-            clearInterval(task);
-            next();
-          }
-        });
-      }
-      var task = setInterval(dbInfo, 50);
-    },
-    function(next) {
-      db.view('alice', 'by_id', next);
-    }
-  ], function(err, view) {
-    assert.equal(err, null, 'should be able to call the view');
-    assert.equal(view['total_rows'], 0, 'and see stuff got deleted');
-    assert.end();
-  });
-});*/

--- a/tests/integration/design/list.js
+++ b/tests/integration/design/list.js
@@ -28,13 +28,13 @@ it('should get the people by running the ddoc', function(assert) {
   }, function(error, list) {
     assert.equal(error, null, 'should response');
     assert.equal(list, 'Hello', 'and list should be `hello`');
-    assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
-  p.then(function(docs) {
+  assert.ok(helpers.isPromise(p), 'returns Promise');
+  p.then(function(list) {
     assert.ok(true, 'Promise is resolved');
     assert.equal(list, 'Hello', 'and list should be `hello`');
-  }).catch(function(error) {
+    assert.end();
+  }).catch(function() {
     assert.ok(false, 'Promise is rejected');
   });
 });

--- a/tests/integration/design/list.js
+++ b/tests/integration/design/list.js
@@ -20,7 +20,7 @@ var db = harness.locals.db;
 it('should create a ddoc and insert some docs', helpers.prepareAView);
 
 it('should get the people by running the ddoc', function(assert) {
-  db.viewWithList('people', 'by_name_and_city', 'my_list', {
+  var p = db.viewWithList('people', 'by_name_and_city', 'my_list', {
     key: [
       'Derek',
       'San Francisco'
@@ -29,5 +29,12 @@ it('should get the people by running the ddoc', function(assert) {
     assert.equal(error, null, 'should response');
     assert.equal(list, 'Hello', 'and list should be `hello`');
     assert.end();
+  });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(docs) {
+    assert.ok(true, 'Promise is resolved');
+    assert.equal(list, 'Hello', 'and list should be `hello`');
+  }).catch(function(error) {
+    assert.ok(false, 'Promise is rejected');
   });
 });

--- a/tests/integration/design/list.js
+++ b/tests/integration/design/list.js
@@ -12,15 +12,15 @@
 
 'use strict';
 
-var helpers = require('../../helpers/integration');
-var harness = helpers.harness(__filename);
-var it = harness.it;
-var db = harness.locals.db;
+const helpers = require('../../helpers/integration');
+const harness = helpers.harness(__filename);
+const it = harness.it;
+const db = harness.locals.db;
 
 it('should create a ddoc and insert some docs', helpers.prepareAView);
 
 it('should get the people by running the ddoc', function(assert) {
-  var p = db.viewWithList('people', 'by_name_and_city', 'my_list', {
+  const p = db.viewWithList('people', 'by_name_and_city', 'my_list', {
     key: [
       'Derek',
       'San Francisco'

--- a/tests/integration/design/multiple.js
+++ b/tests/integration/design/multiple.js
@@ -12,13 +12,13 @@
 
 'use strict';
 
-var helpers = require('../../helpers/integration');
-var harness = helpers.harness(__filename);
-var it = harness.it;
-var db = harness.locals.db;
+const helpers = require('../../helpers/integration');
+const harness = helpers.harness(__filename);
+const it = harness.it;
+const db = harness.locals.db;
 
 it('should be able to insert docs and design doc', function(assert) {
-  var p = db.insert({
+  const p = db.insert({
     views: {
       'by_id': {
         map: 'function(doc) { emit(doc._id, doc); }'
@@ -41,7 +41,7 @@ it('should be able to insert docs and design doc', function(assert) {
 it('should insert a bunch of items', helpers.insertThree);
 
 it('get multiple docs with a composed key', function(assert) {
-  var p = db.view('alice', 'by_id', {
+  const p = db.view('alice', 'by_id', {
     keys: ['foobar', 'barfoo'],
     'include_docs': true
   }, function(err, view) {
@@ -63,7 +63,7 @@ it('get multiple docs with a composed key', function(assert) {
 });
 
 it('get multiple docs with a composed key as a stream', function(assert) {
-  var p = db.viewAsStream('alice', 'by_id', {
+  const p = db.viewAsStream('alice', 'by_id', {
     keys: ['foobar', 'barfoo'],
     'include_docs': true
   }, function(err, view) {

--- a/tests/integration/design/multiple.js
+++ b/tests/integration/design/multiple.js
@@ -62,3 +62,18 @@ it('get multiple docs with a composed key', function(assert) {
     assert.ok(false, 'Promise is rejected');
   });
 });
+
+it('get multiple docs with a composed key as a stream', function(assert) {
+  var p = db.viewAsStream('alice', 'by_id', {
+    keys: ['foobar', 'barfoo'],
+    'include_docs': true
+  }, function(err, view) {
+    assert.equal(err, null, 'should response');
+    assert.equal(view.rows.length, 2, 'has more or less than two rows');
+    assert.equal(view.rows[0].id, 'foobar', 'foo is not the first id');
+    assert.equal(view.rows[1].id, 'barfoo', 'bar is not the second id');
+    assert.end();
+  });
+  assert.ok(!helpers.isPromise(p), 'does not returns Promise')
+  assert.equal(p.constructor.name, 'Request', 'returns a Request')
+});

--- a/tests/integration/design/multiple.js
+++ b/tests/integration/design/multiple.js
@@ -18,7 +18,7 @@ var it = harness.it;
 var db = harness.locals.db;
 
 it('should be able to insert docs and design doc', function(assert) {
-  db.insert({
+  var p = db.insert({
     views: {
       'by_id': {
         map: 'function(doc) { emit(doc._id, doc); }'
@@ -29,12 +29,20 @@ it('should be able to insert docs and design doc', function(assert) {
     assert.equal(response.ok, true, 'response ok');
     assert.end();
   });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(response) {
+    assert.ok(true, 'Promise is resolved');
+    assert.equal(error, null, 'should create views');
+    assert.equal(response.ok, true, 'response ok');
+  }).catch(function(error) {
+    assert.ok(false, 'Promise is rejected');
+  });
 });
 
 it('should insert a bunch of items', helpers.insertThree);
 
 it('get multiple docs with a composed key', function(assert) {
-  db.view('alice', 'by_id', {
+  var p = db.view('alice', 'by_id', {
     keys: ['foobar', 'barfoo'],
     'include_docs': true
   }, function(err, view) {
@@ -43,5 +51,14 @@ it('get multiple docs with a composed key', function(assert) {
     assert.equal(view.rows[0].id, 'foobar', 'foo is not the first id');
     assert.equal(view.rows[1].id, 'barfoo', 'bar is not the second id');
     assert.end();
+  });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(view) {
+    assert.ok(true, 'Promise is resolved');
+    assert.equal(view.rows.length, 2, 'has more or less than two rows');
+    assert.equal(view.rows[0].id, 'foobar', 'foo is not the first id');
+    assert.equal(view.rows[1].id, 'barfoo', 'bar is not the second id');
+  }).catch(function(error) {
+    assert.ok(false, 'Promise is rejected');
   });
 });

--- a/tests/integration/design/multiple.js
+++ b/tests/integration/design/multiple.js
@@ -27,14 +27,13 @@ it('should be able to insert docs and design doc', function(assert) {
   }, '_design/alice', function(error, response) {
     assert.equal(error, null, 'should create views');
     assert.equal(response.ok, true, 'response ok');
-    assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
+  assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(response) {
     assert.ok(true, 'Promise is resolved');
-    assert.equal(error, null, 'should create views');
     assert.equal(response.ok, true, 'response ok');
-  }).catch(function(error) {
+    assert.end();
+  }).catch(function() {
     assert.ok(false, 'Promise is rejected');
   });
 });
@@ -50,15 +49,15 @@ it('get multiple docs with a composed key', function(assert) {
     assert.equal(view.rows.length, 2, 'has more or less than two rows');
     assert.equal(view.rows[0].id, 'foobar', 'foo is not the first id');
     assert.equal(view.rows[1].id, 'barfoo', 'bar is not the second id');
-    assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
+  assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(view) {
     assert.ok(true, 'Promise is resolved');
     assert.equal(view.rows.length, 2, 'has more or less than two rows');
     assert.equal(view.rows[0].id, 'foobar', 'foo is not the first id');
     assert.equal(view.rows[1].id, 'barfoo', 'bar is not the second id');
-  }).catch(function(error) {
+    assert.end();
+  }).catch(function() {
     assert.ok(false, 'Promise is rejected');
   });
 });
@@ -74,6 +73,6 @@ it('get multiple docs with a composed key as a stream', function(assert) {
     assert.equal(view.rows[1].id, 'barfoo', 'bar is not the second id');
     assert.end();
   });
-  assert.ok(!helpers.isPromise(p), 'does not returns Promise')
-  assert.equal(p.constructor.name, 'Request', 'returns a Request')
+  assert.ok(!helpers.isPromise(p), 'does not returns Promise');
+  assert.equal(p.constructor.name, 'Request', 'returns a Request');
 });

--- a/tests/integration/design/query.js
+++ b/tests/integration/design/query.js
@@ -12,14 +12,14 @@
 
 'use strict';
 
-var async = require('async');
-var helpers = require('../../helpers/integration');
-var harness = helpers.harness(__filename);
-var it = harness.it;
-var db = harness.locals.db;
-var viewDerek = helpers.viewDerek;
+const async = require('async');
+const helpers = require('../../helpers/integration');
+const harness = helpers.harness(__filename);
+const it = harness.it;
+const db = harness.locals.db;
+const viewDerek = helpers.viewDerek;
 
-var opts = {key: ['Derek', 'San Francisco']};
+const opts = {key: ['Derek', 'San Francisco']};
 
 it('should create a ddoc and insert some docs', helpers.prepareAView);
 

--- a/tests/integration/design/search.js
+++ b/tests/integration/design/search.js
@@ -12,19 +12,19 @@
 
 'use strict';
 
-var async = require('async');
-var helpers = require('../../helpers/integration');
-var harness = helpers.harness(__filename);
-var it = harness.it;
-var db = harness.locals.db;
-var viewDerek = helpers.viewDerek;
+const async = require('async');
+const helpers = require('../../helpers/integration');
+const harness = helpers.harness(__filename);
+const it = harness.it;
+const db = harness.locals.db;
+const viewDerek = helpers.viewDerek;
 
 //
 // these are cloudant only
 // tests do no run without mocks
 //
 if (helpers.mocked) {
-  var opts = {key: ['Derek', 'San Francisco']};
+  const opts = {key: ['Derek', 'San Francisco']};
 
   it('should create a ddoc and insert some docs', function(assert) {
     helpers.prepareAView(assert, '/_search', db);

--- a/tests/integration/design/show.js
+++ b/tests/integration/design/show.js
@@ -73,13 +73,22 @@ it('should insert a show ddoc', function(assert) {
 });
 
 it('should show the amazing clemens in json', function(assert) {
-  db.show('people', 'singleDoc', 'p_clemens', function(error, doc, rh) {
+  var p = db.show('people', 'singleDoc', 'p_clemens', function(error, doc, rh) {
     assert.equal(error, null, 'its alive');
     assert.equal(rh['content-type'], 'application/json');
     assert.equal(doc.name, 'Clemens');
     assert.equal(doc.city, 'Dresden');
     assert.equal(doc.format, 'json');
     assert.end();
+  });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(doc) {
+    assert.ok(true, 'Promise is resolved');
+    assert.equal(doc.name, 'Clemens');
+    assert.equal(doc.city, 'Dresden');
+    assert.equal(doc.format, 'json');
+  }).catch(function(error) {
+    assert.ok(false, 'Promise is rejected');
   });
 });
 

--- a/tests/integration/design/show.js
+++ b/tests/integration/design/show.js
@@ -79,15 +79,15 @@ it('should show the amazing clemens in json', function(assert) {
     assert.equal(doc.name, 'Clemens');
     assert.equal(doc.city, 'Dresden');
     assert.equal(doc.format, 'json');
-    assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
+  assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(doc) {
     assert.ok(true, 'Promise is resolved');
     assert.equal(doc.name, 'Clemens');
     assert.equal(doc.city, 'Dresden');
     assert.equal(doc.format, 'json');
-  }).catch(function(error) {
+    assert.end();
+  }).catch(function() {
     assert.ok(false, 'Promise is rejected');
   });
 });

--- a/tests/integration/design/show.js
+++ b/tests/integration/design/show.js
@@ -12,11 +12,11 @@
 
 'use strict';
 
-var async = require('async');
-var helpers = require('../../helpers/integration');
-var harness = helpers.harness(__filename);
-var it = harness.it;
-var db = harness.locals.db;
+const async = require('async');
+const helpers = require('../../helpers/integration');
+const harness = helpers.harness(__filename);
+const it = harness.it;
+const db = harness.locals.db;
 
 it('should insert a show ddoc', function(assert) {
   db.insert({
@@ -73,7 +73,7 @@ it('should insert a show ddoc', function(assert) {
 });
 
 it('should show the amazing clemens in json', function(assert) {
-  var p = db.show('people', 'singleDoc', 'p_clemens', function(error, doc, rh) {
+  const p = db.show('people', 'singleDoc', 'p_clemens', function(error, doc, rh) {
     assert.equal(error, null, 'its alive');
     assert.equal(rh['content-type'], 'application/json');
     assert.equal(doc.name, 'Clemens');

--- a/tests/integration/document/bulk.js
+++ b/tests/integration/document/bulk.js
@@ -18,7 +18,7 @@ var it = harness.it;
 var db = harness.locals.db;
 
 it('should be able to bulk insert two docs', function(assert) {
-  db.bulk({
+  var p = db.bulk({
     'docs': [
       {'key':'baz', 'name':'bazzel'},
       {'key':'bar', 'name':'barry'}
@@ -30,5 +30,14 @@ it('should be able to bulk insert two docs', function(assert) {
     assert.ok(response[0].id, 'first got id');
     assert.ok(response[1].id, 'other also got id');
     assert.end();
+  });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(response) {
+    assert.ok(true, 'Promise is resolved');
+    assert.equal(response.length, 2, 'has two docs');
+    assert.ok(response[0].id, 'first got id');
+    assert.ok(response[1].id, 'other also got id');
+  }).catch(function(error) {
+    assert.ok(false, 'Promise is rejected');
   });
 });

--- a/tests/integration/document/bulk.js
+++ b/tests/integration/document/bulk.js
@@ -12,13 +12,13 @@
 
 'use strict';
 
-var helpers = require('../../helpers/integration');
-var harness = helpers.harness(__filename);
-var it = harness.it;
-var db = harness.locals.db;
+const helpers = require('../../helpers/integration');
+const harness = helpers.harness(__filename);
+const it = harness.it;
+const db = harness.locals.db;
 
 it('should be able to bulk insert two docs', function(assert) {
-  var p = db.bulk({
+  const p = db.bulk({
     'docs': [
       {'key':'baz', 'name':'bazzel'},
       {'key':'bar', 'name':'barry'}

--- a/tests/integration/document/bulk.js
+++ b/tests/integration/document/bulk.js
@@ -29,15 +29,15 @@ it('should be able to bulk insert two docs', function(assert) {
     assert.equal(response.length, 2, 'has two docs');
     assert.ok(response[0].id, 'first got id');
     assert.ok(response[1].id, 'other also got id');
-    assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
+  assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(response) {
     assert.ok(true, 'Promise is resolved');
     assert.equal(response.length, 2, 'has two docs');
     assert.ok(response[0].id, 'first got id');
     assert.ok(response[1].id, 'other also got id');
-  }).catch(function(error) {
+    assert.end();
+  }).catch(function() {
     assert.ok(false, 'Promise is rejected');
   });
 });

--- a/tests/integration/document/copy.js
+++ b/tests/integration/document/copy.js
@@ -32,27 +32,45 @@ it('must insert two docs before the tests start', function(assert) {
 });
 
 it('should be able to copy and overwrite a document', function(assert) {
-  db.copy('foo_src', 'foo_dest', {overwrite: true},
+  var p = db.copy('foo_src', 'foo_dest', {overwrite: true},
   function(error, response, headers) {
     assert.equal(error, null,
       'should have copied and overwritten foo_src to foo_dest');
     assert.equal(headers['statusCode'], 201, 'status code should be 201');
     assert.end();
   });
+  assert.ok(helpers.isPromise(p), 'returns Promise');
+  p.then(function(response) {
+    assert.ok(true, 'Promise is resolved');
+  }).catch(function(error) {
+    assert.ok(false, 'Promise is rejected');
+  });
 });
 
 it('copy without overwrite should return conflict for exists docs',
 function(assert) {
-  db.copy('foo_src', 'foo_dest', function(error) {
+  var p = db.copy('foo_src', 'foo_dest', function(error) {
     assert.equal(error.error, 'conflict', 'should be a conflict');
     assert.end();
+  });
+  assert.ok(helpers.isPromise(p), 'returns Promise');
+  p.then(function(response) {
+    assert.ok(false, 'Promise is resolved');
+  }).catch(function(error) {
+    assert.ok(true, 'Promise is rejected');
   });
 });
 
 it('copy to a new destination should work', function(assert) {
-  db.copy('foo_src', 'baz_dest', function(error, response, headers) {
+  var p = db.copy('foo_src', 'baz_dest', function(error, response, headers) {
     assert.equal(error, null, 'copies into new document');
     assert.equal(headers['statusCode'], 201, 'Status code should be 201');
     assert.end();
+  });
+  assert.ok(helpers.isPromise(p), 'returns Promise');
+  p.then(function(response) {
+    assert.ok(true, 'Promise is resolved');
+  }).catch(function(error) {
+    assert.ok(false, 'Promise is rejected');
   });
 });

--- a/tests/integration/document/copy.js
+++ b/tests/integration/document/copy.js
@@ -12,10 +12,10 @@
 
 'use strict';
 
-var helpers = require('../../helpers/integration');
-var harness = helpers.harness(__filename);
-var it = harness.it;
-var db = harness.locals.db;
+const helpers = require('../../helpers/integration');
+const harness = helpers.harness(__filename);
+const it = harness.it;
+const db = harness.locals.db;
 
 it('must insert two docs before the tests start', function(assert) {
   db.insert({'foo': 'baz'}, 'foo_src', function(error, src) {
@@ -32,7 +32,7 @@ it('must insert two docs before the tests start', function(assert) {
 });
 
 it('should be able to copy and overwrite a document', function(assert) {
-  var p = db.copy('foo_src', 'foo_dest', {overwrite: true},
+  const p = db.copy('foo_src', 'foo_dest', {overwrite: true},
   function(error, response, headers) {
     assert.equal(error, null,
       'should have copied and overwritten foo_src to foo_dest');
@@ -49,7 +49,7 @@ it('should be able to copy and overwrite a document', function(assert) {
 
 it('copy without overwrite should return conflict for exists docs',
 function(assert) {
-  var p = db.copy('foo_src', 'foo_dest', function(error) {
+  const p = db.copy('foo_src', 'foo_dest', function(error) {
     assert.equal(error.error, 'conflict', 'should be a conflict');
   });
   assert.ok(helpers.isPromise(p), 'returns Promise');
@@ -62,7 +62,7 @@ function(assert) {
 });
 
 it('copy to a new destination should work', function(assert) {
-  var p = db.copy('foo_src', 'baz_dest', function(error, response, headers) {
+  const p = db.copy('foo_src', 'baz_dest', function(error, response, headers) {
     assert.equal(error, null, 'copies into new document');
     assert.equal(headers['statusCode'], 201, 'Status code should be 201');
   });

--- a/tests/integration/document/copy.js
+++ b/tests/integration/document/copy.js
@@ -37,12 +37,12 @@ it('should be able to copy and overwrite a document', function(assert) {
     assert.equal(error, null,
       'should have copied and overwritten foo_src to foo_dest');
     assert.equal(headers['statusCode'], 201, 'status code should be 201');
-    assert.end();
   });
   assert.ok(helpers.isPromise(p), 'returns Promise');
-  p.then(function(response) {
+  p.then(function() {
     assert.ok(true, 'Promise is resolved');
-  }).catch(function(error) {
+    assert.end();
+  }).catch(function() {
     assert.ok(false, 'Promise is rejected');
   });
 });
@@ -51,13 +51,13 @@ it('copy without overwrite should return conflict for exists docs',
 function(assert) {
   var p = db.copy('foo_src', 'foo_dest', function(error) {
     assert.equal(error.error, 'conflict', 'should be a conflict');
-    assert.end();
   });
   assert.ok(helpers.isPromise(p), 'returns Promise');
-  p.then(function(response) {
+  p.then(function() {
     assert.ok(false, 'Promise is resolved');
-  }).catch(function(error) {
+  }).catch(function() {
     assert.ok(true, 'Promise is rejected');
+    assert.end();
   });
 });
 
@@ -65,12 +65,12 @@ it('copy to a new destination should work', function(assert) {
   var p = db.copy('foo_src', 'baz_dest', function(error, response, headers) {
     assert.equal(error, null, 'copies into new document');
     assert.equal(headers['statusCode'], 201, 'Status code should be 201');
-    assert.end();
   });
   assert.ok(helpers.isPromise(p), 'returns Promise');
-  p.then(function(response) {
+  p.then(function() {
     assert.ok(true, 'Promise is resolved');
-  }).catch(function(error) {
+    assert.end();
+  }).catch(function() {
     assert.ok(false, 'Promise is rejected');
   });
 });

--- a/tests/integration/document/create_index.js
+++ b/tests/integration/document/create_index.js
@@ -20,7 +20,7 @@ var it = harness.it;
 it('should insert a one item', helpers.insertOne);
 
 it ('Should create one simple index', function(assert) {
-  db.createIndex({
+  var p = db.createIndex({
     name: 'fooindex',
     index: { fields: ['foo'] }
   }, function(error, foo) {
@@ -29,5 +29,12 @@ it ('Should create one simple index', function(assert) {
     assert.equal(foo.name, 'fooindex', 'index should have correct name');
 
     assert.end();
+  });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(response) {
+    assert.equal(foo.result, 'created', 'index should be created');
+    assert.equal(foo.name, 'fooindex', 'index should have correct name');
+  }).catch(function(error) {
+    assert.ok(false, 'Promise is rejected');
   });
 });

--- a/tests/integration/document/create_index.js
+++ b/tests/integration/document/create_index.js
@@ -12,15 +12,15 @@
 
 'use strict';
 
-var helpers = require('../../helpers/integration');
-var harness = helpers.harness(__filename);
-var db = harness.locals.db;
-var it = harness.it;
+const helpers = require('../../helpers/integration');
+const harness = helpers.harness(__filename);
+const db = harness.locals.db;
+const it = harness.it;
 
 it('should insert a one item', helpers.insertOne);
 
 it ('Should create one simple index', function(assert) {
-  var p = db.createIndex({
+  const p = db.createIndex({
     name: 'fooindex',
     index: { fields: ['foo'] }
   }, function(error, foo) {

--- a/tests/integration/document/create_index.js
+++ b/tests/integration/document/create_index.js
@@ -27,14 +27,13 @@ it ('Should create one simple index', function(assert) {
     assert.equal(error, null, 'should have indexed fields');
     assert.equal(foo.result, 'created', 'index should be created');
     assert.equal(foo.name, 'fooindex', 'index should have correct name');
-
-    assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
-  p.then(function(response) {
+  assert.ok(helpers.isPromise(p), 'returns Promise');
+  p.then(function(foo) {
     assert.equal(foo.result, 'created', 'index should be created');
     assert.equal(foo.name, 'fooindex', 'index should have correct name');
-  }).catch(function(error) {
+    assert.end();
+  }).catch(function() {
     assert.ok(false, 'Promise is rejected');
   });
 });

--- a/tests/integration/document/destroy.js
+++ b/tests/integration/document/destroy.js
@@ -33,12 +33,12 @@ it('should not delete a db', function(assert) {
   var p = db.destroy(undefined, undefined, function(error, response) {
     assert.equal(error, 'Invalid doc id', 'validated delete parameters');
     assert.equal(response, null, 'ok!');
-    assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
-  p.then(function(response) {
+  assert.ok(helpers.isPromise(p), 'returns Promise');
+  p.then(function() {
     assert.ok(false, 'Promise is resolved');
-  }).catch(function(error) {
+    assert.end();
+  }).catch(function() {
     assert.ok(true, 'Promise is rejected');
   });
 });
@@ -47,13 +47,13 @@ it('should delete a document', function(assert) {
   var p = db.destroy('foobaz', rev, function(error, response) {
     assert.equal(error, null, 'deleted foo');
     assert.equal(response.ok, true, 'ok!');
-    assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
+  assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(response) {
     assert.ok(true, 'Promise is resolved');
     assert.equal(response.ok, true, 'ok!');
-  }).catch(function(error) {
+    assert.end();
+  }).catch(function() {
     assert.ok(false, 'Promise is rejected');
   });
 });

--- a/tests/integration/document/destroy.js
+++ b/tests/integration/document/destroy.js
@@ -12,12 +12,12 @@
 
 'use strict';
 
-var helpers = require('../../helpers/integration');
-var harness = helpers.harness(__filename);
-var it = harness.it;
-var db = harness.locals.db;
+const helpers = require('../../helpers/integration');
+const harness = helpers.harness(__filename);
+const it = harness.it;
+const db = harness.locals.db;
 
-var rev;
+let rev;
 
 it('should insert a document', function(assert) {
   db.insert({'foo': 'baz'}, 'foobaz', function(error, foo) {
@@ -30,7 +30,7 @@ it('should insert a document', function(assert) {
 });
 
 it('should not delete a db', function(assert) {
-  var p = db.destroy(undefined, undefined, function(error, response) {
+  const p = db.destroy(undefined, undefined, function(error, response) {
     assert.equal(error, 'Invalid doc id', 'validated delete parameters');
     assert.equal(response, null, 'ok!');
   });
@@ -44,7 +44,7 @@ it('should not delete a db', function(assert) {
 });
 
 it('should delete a document', function(assert) {
-  var p = db.destroy('foobaz', rev, function(error, response) {
+  const p = db.destroy('foobaz', rev, function(error, response) {
     assert.equal(error, null, 'deleted foo');
     assert.equal(response.ok, true, 'ok!');
   });

--- a/tests/integration/document/destroy.js
+++ b/tests/integration/document/destroy.js
@@ -30,17 +30,30 @@ it('should insert a document', function(assert) {
 });
 
 it('should not delete a db', function(assert) {
-  db.destroy(undefined, undefined, function(error, response) {
+  var p = db.destroy(undefined, undefined, function(error, response) {
     assert.equal(error, 'Invalid doc id', 'validated delete parameters');
     assert.equal(response, null, 'ok!');
     assert.end();
   });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(response) {
+    assert.ok(false, 'Promise is resolved');
+  }).catch(function(error) {
+    assert.ok(true, 'Promise is rejected');
+  });
 });
 
 it('should delete a document', function(assert) {
-  db.destroy('foobaz', rev, function(error, response) {
+  var p = db.destroy('foobaz', rev, function(error, response) {
     assert.equal(error, null, 'deleted foo');
     assert.equal(response.ok, true, 'ok!');
     assert.end();
+  });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(response) {
+    assert.ok(true, 'Promise is resolved');
+    assert.equal(response.ok, true, 'ok!');
+  }).catch(function(error) {
+    assert.ok(false, 'Promise is rejected');
   });
 });

--- a/tests/integration/document/fetch.js
+++ b/tests/integration/document/fetch.js
@@ -12,15 +12,15 @@
 
 'use strict';
 
-var helpers = require('../../helpers/integration');
-var harness = helpers.harness(__filename);
-var db = harness.locals.db;
-var it = harness.it;
+const helpers = require('../../helpers/integration');
+const harness = helpers.harness(__filename);
+const db = harness.locals.db;
+const it = harness.it;
 
 it('should insert a bunch of items', helpers.insertThree);
 
 it('should be able to fetch with one key', function(assert) {
-  var p = db.fetch({keys:['foobar']}, function(error, docs) {
+  const p = db.fetch({keys:['foobar']}, function(error, docs) {
     assert.equal(error, null, 'should work');
     assert.equal(docs.rows.length, 1, 'and get one row');
     assert.equal(docs['total_rows'], 3, 'out of 3');
@@ -37,7 +37,7 @@ it('should be able to fetch with one key', function(assert) {
 });
 
 it('should be able to fetch with multiple keys', function(assert) {
-  var p = db.fetch({keys:['foobar', 'barfoo']}, function(error, docs) {
+  const p = db.fetch({keys:['foobar', 'barfoo']}, function(error, docs) {
     assert.equal(error, null, 'no errors');
     assert.equal(docs.rows.length, 2, 'two rows');
     assert.equal(docs['total_rows'], 3, 'out of 3');
@@ -54,7 +54,7 @@ it('should be able to fetch with multiple keys', function(assert) {
 });
 
 it('should be able to fetch with params', function(assert) {
-  var p = db.fetch({keys:['foobar']}, {not: 'important'}, function(error, docs) {
+  const p = db.fetch({keys:['foobar']}, {not: 'important'}, function(error, docs) {
     assert.equal(error, null, 'should work');
     assert.equal(docs.rows.length, 1, 'and get one row');
     assert.equal(docs['total_rows'], 3, 'out of 3');

--- a/tests/integration/document/fetch.js
+++ b/tests/integration/document/fetch.js
@@ -20,28 +20,52 @@ var it = harness.it;
 it('should insert a bunch of items', helpers.insertThree);
 
 it('should be able to fetch with one key', function(assert) {
-  db.fetch({keys:['foobar']}, function(error, docs) {
+  var p = db.fetch({keys:['foobar']}, function(error, docs) {
     assert.equal(error, null, 'should work');
     assert.equal(docs.rows.length, 1, 'and get one row');
     assert.equal(docs['total_rows'], 3, 'out of 3');
     assert.end();
   });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(docs) {
+    assert.ok(true, 'Promise is resolved');
+    assert.equal(docs.rows.length, 1, 'and get one row');
+    assert.equal(docs['total_rows'], 3, 'out of 3');
+  }).catch(function(error) {
+    assert.ok(false, 'Promise is rejected');
+  });
 });
 
 it('should be able to fetch with multiple keys', function(assert) {
-  db.fetch({keys:['foobar', 'barfoo']}, function(error, docs) {
+  var p = db.fetch({keys:['foobar', 'barfoo']}, function(error, docs) {
     assert.equal(error, null, 'no errors');
     assert.equal(docs.rows.length, 2, 'two rows');
     assert.equal(docs['total_rows'], 3, 'out of 3');
     assert.end();
   });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(docs) {
+    assert.ok(true, 'Promise is resolved');
+    assert.equal(docs.rows.length, 2, 'two rows');
+    assert.equal(docs['total_rows'], 3, 'out of 3');
+  }).catch(function(error) {
+    assert.ok(false, 'Promise is rejected');
+  });
 });
 
 it('should be able to fetch with params', function(assert) {
-  db.fetch({keys:['foobar']}, {not: 'important'}, function(error, docs) {
+  var p = db.fetch({keys:['foobar']}, {not: 'important'}, function(error, docs) {
     assert.equal(error, null, 'should work');
     assert.equal(docs.rows.length, 1, 'and get one row');
     assert.equal(docs['total_rows'], 3, 'out of 3');
     assert.end();
+  });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(docs) {
+    assert.ok(true, 'Promise is resolved');
+    assert.equal(docs.rows.length, 1, 'and get one row');
+    assert.equal(docs['total_rows'], 3, 'out of 3');
+  }).catch(function(error) {
+    assert.ok(false, 'Promise is rejected');
   });
 });

--- a/tests/integration/document/fetch.js
+++ b/tests/integration/document/fetch.js
@@ -24,14 +24,14 @@ it('should be able to fetch with one key', function(assert) {
     assert.equal(error, null, 'should work');
     assert.equal(docs.rows.length, 1, 'and get one row');
     assert.equal(docs['total_rows'], 3, 'out of 3');
-    assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
+  assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(docs) {
     assert.ok(true, 'Promise is resolved');
     assert.equal(docs.rows.length, 1, 'and get one row');
     assert.equal(docs['total_rows'], 3, 'out of 3');
-  }).catch(function(error) {
+    assert.end();
+  }).catch(function() {
     assert.ok(false, 'Promise is rejected');
   });
 });
@@ -41,14 +41,14 @@ it('should be able to fetch with multiple keys', function(assert) {
     assert.equal(error, null, 'no errors');
     assert.equal(docs.rows.length, 2, 'two rows');
     assert.equal(docs['total_rows'], 3, 'out of 3');
-    assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
+  assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(docs) {
     assert.ok(true, 'Promise is resolved');
     assert.equal(docs.rows.length, 2, 'two rows');
     assert.equal(docs['total_rows'], 3, 'out of 3');
-  }).catch(function(error) {
+    assert.end();
+  }).catch(function() {
     assert.ok(false, 'Promise is rejected');
   });
 });
@@ -58,14 +58,14 @@ it('should be able to fetch with params', function(assert) {
     assert.equal(error, null, 'should work');
     assert.equal(docs.rows.length, 1, 'and get one row');
     assert.equal(docs['total_rows'], 3, 'out of 3');
-    assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
+  assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(docs) {
     assert.ok(true, 'Promise is resolved');
     assert.equal(docs.rows.length, 1, 'and get one row');
     assert.equal(docs['total_rows'], 3, 'out of 3');
-  }).catch(function(error) {
+    assert.end();
+  }).catch(function() {
     assert.ok(false, 'Promise is rejected');
   });
 });

--- a/tests/integration/document/fetch_revs.js
+++ b/tests/integration/document/fetch_revs.js
@@ -12,15 +12,15 @@
 
 'use strict';
 
-var helpers = require('../../helpers/integration');
-var harness = helpers.harness(__filename);
-var db = harness.locals.db;
-var it = harness.it;
+const helpers = require('../../helpers/integration');
+const harness = helpers.harness(__filename);
+const db = harness.locals.db;
+const it = harness.it;
 
 it('should insert a bunch of items', helpers.insertThree);
 
 it('should be able to fetch with one key', function(assert) {
-  var p = db.fetchRevs({keys:['foobar']}, function(error, docs) {
+  const p = db.fetchRevs({keys:['foobar']}, function(error, docs) {
     assert.equal(error, null, 'should work');
     assert.equal(docs.rows.length, 1, 'and get one row');
     assert.equal(docs['total_rows'], 3, 'out of 3');
@@ -39,7 +39,7 @@ it('should be able to fetch with one key', function(assert) {
 });
 
 it('should be able to fetch with multiple keys', function(assert) {
-  var p = db.fetchRevs({keys:['foobar', 'barfoo']}, function(error, docs) {
+  const p = db.fetchRevs({keys:['foobar', 'barfoo']}, function(error, docs) {
     assert.equal(error, null, 'it works');
     assert.equal(docs.rows.length, 2, 'two rows');
     assert.equal(docs['total_rows'], 3, 'out of 3');
@@ -60,7 +60,7 @@ it('should be able to fetch with multiple keys', function(assert) {
 });
 
 it('should be able to fetch with params', function(assert) {
-  var p = db.fetchRevs({keys:['foobar']}, {still: 'no'}, function(error, docs) {
+  const p = db.fetchRevs({keys:['foobar']}, {still: 'no'}, function(error, docs) {
     assert.equal(error, null, 'should work');
     assert.equal(docs.rows.length, 1, 'and get one row');
     assert.equal(docs['total_rows'], 3, 'out of 3');

--- a/tests/integration/document/fetch_revs.js
+++ b/tests/integration/document/fetch_revs.js
@@ -20,17 +20,26 @@ var it = harness.it;
 it('should insert a bunch of items', helpers.insertThree);
 
 it('should be able to fetch with one key', function(assert) {
-  db.fetchRevs({keys:['foobar']}, function(error, docs) {
+  var p = db.fetchRevs({keys:['foobar']}, function(error, docs) {
     assert.equal(error, null, 'should work');
     assert.equal(docs.rows.length, 1, 'and get one row');
     assert.equal(docs['total_rows'], 3, 'out of 3');
     assert.equal(docs.rows[0].doc, undefined, 'rev should not return key');
     assert.end();
   });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(docs) {
+    assert.ok(true, 'Promise is resolved');
+    assert.equal(docs.rows.length, 1, 'and get one row');
+    assert.equal(docs['total_rows'], 3, 'out of 3');
+    assert.equal(docs.rows[0].doc, undefined, 'rev should not return key');
+  }).catch(function(error) {
+    assert.ok(false, 'Promise is rejected');
+  });
 });
 
 it('should be able to fetch with multiple keys', function(assert) {
-  db.fetchRevs({keys:['foobar', 'barfoo']}, function(error, docs) {
+  var p = db.fetchRevs({keys:['foobar', 'barfoo']}, function(error, docs) {
     assert.equal(error, null, 'it works');
     assert.equal(docs.rows.length, 2, 'two rows');
     assert.equal(docs['total_rows'], 3, 'out of 3');
@@ -38,14 +47,33 @@ it('should be able to fetch with multiple keys', function(assert) {
     assert.equal(docs.rows[1].doc, undefined, 'no doc in 2');
     assert.end();
   });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(docs) {
+    assert.ok(true, 'Promise is resolved');
+    assert.equal(docs.rows.length, 2, 'two rows');
+    assert.equal(docs['total_rows'], 3, 'out of 3');
+    assert.equal(docs.rows[0].doc, undefined, 'no doc in 1');
+    assert.equal(docs.rows[1].doc, undefined, 'no doc in 2');
+  }).catch(function(error) {
+    assert.ok(false, 'Promise is rejected');
+  });
 });
 
 it('should be able to fetch with params', function(assert) {
-  db.fetchRevs({keys:['foobar']}, {still: 'no'}, function(error, docs) {
+  var p = db.fetchRevs({keys:['foobar']}, {still: 'no'}, function(error, docs) {
     assert.equal(error, null, 'should work');
     assert.equal(docs.rows.length, 1, 'and get one row');
     assert.equal(docs['total_rows'], 3, 'out of 3');
     assert.equal(docs.rows[0].doc, undefined, 'rev should not return key');
     assert.end();
+  });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(docs) {
+    assert.ok(true, 'Promise is resolved');
+    assert.equal(docs.rows.length, 1, 'and get one row');
+    assert.equal(docs['total_rows'], 3, 'out of 3');
+    assert.equal(docs.rows[0].doc, undefined, 'rev should not return key');
+  }).catch(function(error) {
+    assert.ok(false, 'Promise is rejected');
   });
 });

--- a/tests/integration/document/fetch_revs.js
+++ b/tests/integration/document/fetch_revs.js
@@ -25,15 +25,15 @@ it('should be able to fetch with one key', function(assert) {
     assert.equal(docs.rows.length, 1, 'and get one row');
     assert.equal(docs['total_rows'], 3, 'out of 3');
     assert.equal(docs.rows[0].doc, undefined, 'rev should not return key');
-    assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
+  assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(docs) {
     assert.ok(true, 'Promise is resolved');
     assert.equal(docs.rows.length, 1, 'and get one row');
     assert.equal(docs['total_rows'], 3, 'out of 3');
     assert.equal(docs.rows[0].doc, undefined, 'rev should not return key');
-  }).catch(function(error) {
+    assert.end();
+  }).catch(function() {
     assert.ok(false, 'Promise is rejected');
   });
 });
@@ -45,16 +45,16 @@ it('should be able to fetch with multiple keys', function(assert) {
     assert.equal(docs['total_rows'], 3, 'out of 3');
     assert.equal(docs.rows[0].doc, undefined, 'no doc in 1');
     assert.equal(docs.rows[1].doc, undefined, 'no doc in 2');
-    assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
+  assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(docs) {
     assert.ok(true, 'Promise is resolved');
     assert.equal(docs.rows.length, 2, 'two rows');
     assert.equal(docs['total_rows'], 3, 'out of 3');
     assert.equal(docs.rows[0].doc, undefined, 'no doc in 1');
     assert.equal(docs.rows[1].doc, undefined, 'no doc in 2');
-  }).catch(function(error) {
+    assert.end();
+  }).catch(function() {
     assert.ok(false, 'Promise is rejected');
   });
 });
@@ -65,15 +65,15 @@ it('should be able to fetch with params', function(assert) {
     assert.equal(docs.rows.length, 1, 'and get one row');
     assert.equal(docs['total_rows'], 3, 'out of 3');
     assert.equal(docs.rows[0].doc, undefined, 'rev should not return key');
-    assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
+  assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(docs) {
     assert.ok(true, 'Promise is resolved');
     assert.equal(docs.rows.length, 1, 'and get one row');
     assert.equal(docs['total_rows'], 3, 'out of 3');
     assert.equal(docs.rows[0].doc, undefined, 'rev should not return key');
-  }).catch(function(error) {
+    assert.end();
+  }).catch(function() {
     assert.ok(false, 'Promise is rejected');
   });
 });

--- a/tests/integration/document/find.js
+++ b/tests/integration/document/find.js
@@ -1,0 +1,45 @@
+// Licensed under the Apache License, Version 2.0 (the 'License'); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+'use strict';
+
+var helpers = require('../../helpers/integration');
+var harness = helpers.harness(__filename);
+var db = harness.locals.db;
+var it = harness.it;
+
+it('should insert a bunch of items', helpers.insertThree);
+
+it('should be to do a mango query', function(assert) {
+  var p = db.find({ selector: { foo: 'baz'}}, function(error, response) {
+    assert.equal(error, null, 'should work');
+    assert.equal(response.docs.length, 1, 'and get one row');
+    assert.end();
+  });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(response) {
+    assert.ok(true, 'Promise is resolved');
+    assert.equal(response.docs.length, 1, 'and get one row');
+  }).catch(function(error) {
+    assert.ok(false, 'Promise is rejected');
+  });
+});
+
+it('should be to do a mango query with streams', function(assert) {
+  var p = db.findAsStream({ selector: { foo: 'baz'}}, function(error, response) {
+    assert.equal(error, null, 'should work');
+    assert.equal(response.docs.length, 1, 'and get one row');
+    assert.end();
+  });
+  assert.ok(!helpers.isPromise(p), 'does not return Promise')
+  assert.equal(p.constructor.name, 'Request', 'returns a Request')
+});

--- a/tests/integration/document/find.js
+++ b/tests/integration/document/find.js
@@ -12,15 +12,15 @@
 
 'use strict';
 
-var helpers = require('../../helpers/integration');
-var harness = helpers.harness(__filename);
-var db = harness.locals.db;
-var it = harness.it;
+const helpers = require('../../helpers/integration');
+const harness = helpers.harness(__filename);
+const db = harness.locals.db;
+const it = harness.it;
 
 it('should insert a bunch of items', helpers.insertThree);
 
 it('should be to do a mango query', function(assert) {
-  var p = db.find({ selector: { foo: 'baz'}}, function(error, response) {
+  const p = db.find({ selector: { foo: 'baz'}}, function(error, response) {
     assert.equal(error, null, 'should work');
     assert.equal(response.docs.length, 1, 'and get one row');
   });
@@ -35,7 +35,7 @@ it('should be to do a mango query', function(assert) {
 });
 
 it('should be to do a mango query with streams', function(assert) {
-  var p = db.findAsStream({ selector: { foo: 'baz'}}, function(error, response) {
+  const p = db.findAsStream({ selector: { foo: 'baz'}}, function(error, response) {
     assert.equal(error, null, 'should work');
     assert.equal(response.docs.length, 1, 'and get one row');
     assert.end();

--- a/tests/integration/document/find.js
+++ b/tests/integration/document/find.js
@@ -23,13 +23,13 @@ it('should be to do a mango query', function(assert) {
   var p = db.find({ selector: { foo: 'baz'}}, function(error, response) {
     assert.equal(error, null, 'should work');
     assert.equal(response.docs.length, 1, 'and get one row');
-    assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
+  assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(response) {
     assert.ok(true, 'Promise is resolved');
     assert.equal(response.docs.length, 1, 'and get one row');
-  }).catch(function(error) {
+    assert.end();
+  }).catch(function() {
     assert.ok(false, 'Promise is rejected');
   });
 });
@@ -40,6 +40,6 @@ it('should be to do a mango query with streams', function(assert) {
     assert.equal(response.docs.length, 1, 'and get one row');
     assert.end();
   });
-  assert.ok(!helpers.isPromise(p), 'does not return Promise')
-  assert.equal(p.constructor.name, 'Request', 'returns a Request')
+  assert.ok(!helpers.isPromise(p), 'does not return Promise');
+  assert.equal(p.constructor.name, 'Request', 'returns a Request');
 });

--- a/tests/integration/document/get.js
+++ b/tests/integration/document/get.js
@@ -12,15 +12,15 @@
 
 'use strict';
 
-var helpers = require('../../helpers/integration');
-var harness = helpers.harness(__filename);
-var db = harness.locals.db;
-var it = harness.it;
+const helpers = require('../../helpers/integration');
+const harness = helpers.harness(__filename);
+const db = harness.locals.db;
+const it = harness.it;
 
 it('should insert a one item', helpers.insertOne);
 
 it('should get the document', function(assert) {
-  var p = db.get('foobaz', {'revs_info': true}, function(error, foobaz) {
+  const p = db.get('foobaz', {'revs_info': true}, function(error, foobaz) {
     assert.equal(error, null, 'should get foobaz');
     assert.ok(foobaz['_revs_info'], 'got revs info');
     assert.equal(foobaz._id, 'foobaz', 'id is food');

--- a/tests/integration/document/get.js
+++ b/tests/integration/document/get.js
@@ -20,11 +20,20 @@ var it = harness.it;
 it('should insert a one item', helpers.insertOne);
 
 it('should get the document', function(assert) {
-  db.get('foobaz', {'revs_info': true}, function(error, foobaz) {
+  var p = db.get('foobaz', {'revs_info': true}, function(error, foobaz) {
     assert.equal(error, null, 'should get foobaz');
     assert.ok(foobaz['_revs_info'], 'got revs info');
     assert.equal(foobaz._id, 'foobaz', 'id is food');
     assert.equal(foobaz.foo, 'baz', 'baz is in foo');
     assert.end();
+  });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(docs) {
+    assert.ok(true, 'Promise is resolved');
+    assert.ok(foobaz['_revs_info'], 'got revs info');
+    assert.equal(foobaz._id, 'foobaz', 'id is food');
+    assert.equal(foobaz.foo, 'baz', 'baz is in foo');
+  }).catch(function(error) {
+    assert.ok(false, 'Promise is rejected');
   });
 });

--- a/tests/integration/document/get.js
+++ b/tests/integration/document/get.js
@@ -25,15 +25,15 @@ it('should get the document', function(assert) {
     assert.ok(foobaz['_revs_info'], 'got revs info');
     assert.equal(foobaz._id, 'foobaz', 'id is food');
     assert.equal(foobaz.foo, 'baz', 'baz is in foo');
-    assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
-  p.then(function(docs) {
+  assert.ok(helpers.isPromise(p), 'returns Promise');
+  p.then(function(foobaz) {
     assert.ok(true, 'Promise is resolved');
     assert.ok(foobaz['_revs_info'], 'got revs info');
     assert.equal(foobaz._id, 'foobaz', 'id is food');
     assert.equal(foobaz.foo, 'baz', 'baz is in foo');
-  }).catch(function(error) {
+    assert.end();
+  }).catch(function() {
     assert.ok(false, 'Promise is rejected');
   });
 });

--- a/tests/integration/document/head.js
+++ b/tests/integration/document/head.js
@@ -28,6 +28,7 @@ it('should get a status code when you do head', function(assert) {
   assert.ok(helpers.isPromise(p), 'returns Promise')
   p.then(function(docs) {
     assert.ok(true, 'Promise is resolved');
+    assert.equal(docs['statusCode'], 200, 'and is ok');
   }).catch(function(error) {
     assert.ok(false, 'Promise is rejected');
   });

--- a/tests/integration/document/head.js
+++ b/tests/integration/document/head.js
@@ -20,9 +20,15 @@ var it = harness.it;
 it('should insert a one item', helpers.insertOne);
 
 it('should get a status code when you do head', function(assert) {
-  db.head('foobaz', function(error, body, headers) {
+  var p = db.head('foobaz', function(error, body, headers) {
     assert.equal(error, null, 'should get the head of foobaz');
     assert.equal(headers['statusCode'], 200, 'and is ok');
     assert.end();
+  });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(docs) {
+    assert.ok(true, 'Promise is resolved');
+  }).catch(function(error) {
+    assert.ok(false, 'Promise is rejected');
   });
 });

--- a/tests/integration/document/head.js
+++ b/tests/integration/document/head.js
@@ -23,13 +23,13 @@ it('should get a status code when you do head', function(assert) {
   var p = db.head('foobaz', function(error, body, headers) {
     assert.equal(error, null, 'should get the head of foobaz');
     assert.equal(headers['statusCode'], 200, 'and is ok');
-    assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
+  assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(docs) {
     assert.ok(true, 'Promise is resolved');
     assert.equal(docs['statusCode'], 200, 'and is ok');
-  }).catch(function(error) {
+    assert.end();
+  }).catch(function() {
     assert.ok(false, 'Promise is rejected');
   });
 });

--- a/tests/integration/document/head.js
+++ b/tests/integration/document/head.js
@@ -12,15 +12,15 @@
 
 'use strict';
 
-var helpers = require('../../helpers/integration');
-var harness = helpers.harness(__filename);
-var db = harness.locals.db;
-var it = harness.it;
+const helpers = require('../../helpers/integration');
+const harness = helpers.harness(__filename);
+const db = harness.locals.db;
+const it = harness.it;
 
 it('should insert a one item', helpers.insertOne);
 
 it('should get a status code when you do head', function(assert) {
-  var p = db.head('foobaz', function(error, body, headers) {
+  const p = db.head('foobaz', function(error, body, headers) {
     assert.equal(error, null, 'should get the head of foobaz');
     assert.equal(headers['statusCode'], 200, 'and is ok');
   });

--- a/tests/integration/document/insert.js
+++ b/tests/integration/document/insert.js
@@ -20,26 +20,42 @@ var it = harness.it;
 var rev;
 
 it('should insert one simple document', function(assert) {
-  db.insert({'foo': 'baz'}, 'foobaz', function(error, foo) {
+  var p = db.insert({'foo': 'baz'}, 'foobaz', function(error, foo) {
     rev = foo.rev;
     assert.equal(error, null, 'should have stored foo');
     assert.equal(foo.ok, true, 'response should be ok');
     assert.ok(foo.rev, 'response should have rev');
     assert.end();
   });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(foo) {
+    assert.ok(true, 'Promise is resolved');
+    assert.equal(foo.ok, true, 'response should be ok');
+    assert.ok(foo.rev, 'response should have rev');
+  }).catch(function(error) {
+    assert.ok(false, 'Promise is rejected');
+  });
 });
 
 it('should fail to insert again since it already exists', function(assert) {
-  db.insert({}, 'foobaz', function(error) {
+  var p = db.insert({}, 'foobaz', function(error) {
     assert.equal(error['statusCode'], 409, 'should be conflict');
     assert.equal(error.scope, 'couch', 'scope is couch');
     assert.equal(error.error, 'conflict', 'type is conflict');
     assert.end();
   });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(foo) {
+    assert.ok(false, 'Promise is resolved');
+  }).catch(function(error) {
+    assert.ok(true, 'Promise is rejected');
+    assert.equal(error.scope, 'couch', 'scope is couch');
+    assert.equal(error.error, 'conflict', 'type is conflict');
+  });
 });
 
 it('should be able to use custom params in insert', function(assert) {
-  db.insert({
+  var p = db.insert({
     foo: 'baz',
     _rev: rev
   }, {
@@ -51,10 +67,18 @@ it('should be able to use custom params in insert', function(assert) {
     assert.ok(foo.rev, 'response should have rev');
     assert.end();
   });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(foo) {
+    assert.ok(true, 'Promise is resolved');
+    assert.equal(foo.ok, true, 'response should be ok');
+    assert.ok(foo.rev, 'response should have rev');
+  }).catch(function(error) {
+    assert.ok(false, 'Promise is rejected');
+  });
 });
 
 it('should be able to insert functions in docs', function(assert) {
-  db.insert({
+  var p = db.insert({
     fn: function() { return true; },
     fn2: 'function () { return true; }'
   }, function(error, fns) {
@@ -66,6 +90,14 @@ it('should be able to insert functions in docs', function(assert) {
       assert.equal(error, null, 'should get foo');
       assert.end();
     });
+  });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(foo) {
+    assert.ok(true, 'Promise is resolved');
+    assert.equal(fns.ok, true, 'response should be ok');
+    assert.ok(fns.rev, 'response should have rev');
+  }).catch(function(error) {
+    assert.ok(false, 'Promise is rejected');
   });
 });
 

--- a/tests/integration/document/insert.js
+++ b/tests/integration/document/insert.js
@@ -71,7 +71,7 @@ it('should be able to insert functions in docs', function(assert) {
 
 it('should be able to stream an insert', function(assert) {
   var buffer = '';
-  var foobar = db.insert({'foo': 'bar'});
+  var foobar = db.insertAsStream({'foo': 'bar'});
 
   function runAssertions(error, foobar) {
     assert.equal(error, null, 'should have stored foobar');

--- a/tests/integration/document/insert.js
+++ b/tests/integration/document/insert.js
@@ -12,15 +12,15 @@
 
 'use strict';
 
-var helpers = require('../../helpers/integration');
-var harness = helpers.harness(__filename);
-var db = harness.locals.db;
-var it = harness.it;
+const helpers = require('../../helpers/integration');
+const harness = helpers.harness(__filename);
+const db = harness.locals.db;
+const it = harness.it;
 
-var rev;
+let rev;
 
 it('should insert one simple document', function(assert) {
-  var p = db.insert({'foo': 'baz'}, 'foobaz', function(error, foo) {
+  const p = db.insert({'foo': 'baz'}, 'foobaz', function(error, foo) {
     rev = foo.rev;
     assert.equal(error, null, 'should have stored foo');
     assert.equal(foo.ok, true, 'response should be ok');
@@ -38,7 +38,7 @@ it('should insert one simple document', function(assert) {
 });
 
 it('should fail to insert again since it already exists', function(assert) {
-  var p = db.insert({}, 'foobaz', function(error) {
+  const p = db.insert({}, 'foobaz', function(error) {
     assert.equal(error['statusCode'], 409, 'should be conflict');
     assert.equal(error.scope, 'couch', 'scope is couch');
     assert.equal(error.error, 'conflict', 'type is conflict');
@@ -55,7 +55,7 @@ it('should fail to insert again since it already exists', function(assert) {
 });
 
 it('should be able to use custom params in insert', function(assert) {
-  var p = db.insert({
+  const p = db.insert({
     foo: 'baz',
     _rev: rev
   }, {
@@ -78,7 +78,7 @@ it('should be able to use custom params in insert', function(assert) {
 });
 
 it('should be able to insert functions in docs', function(assert) {
-  var p = db.insert({
+  const p = db.insert({
     fn: function() { return true; },
     fn2: 'function () { return true; }'
   }, function(error, fns) {

--- a/tests/integration/document/insert.js
+++ b/tests/integration/document/insert.js
@@ -25,14 +25,14 @@ it('should insert one simple document', function(assert) {
     assert.equal(error, null, 'should have stored foo');
     assert.equal(foo.ok, true, 'response should be ok');
     assert.ok(foo.rev, 'response should have rev');
-    assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
+  assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(foo) {
     assert.ok(true, 'Promise is resolved');
     assert.equal(foo.ok, true, 'response should be ok');
     assert.ok(foo.rev, 'response should have rev');
-  }).catch(function(error) {
+    assert.end();
+  }).catch(function() {
     assert.ok(false, 'Promise is rejected');
   });
 });
@@ -42,15 +42,15 @@ it('should fail to insert again since it already exists', function(assert) {
     assert.equal(error['statusCode'], 409, 'should be conflict');
     assert.equal(error.scope, 'couch', 'scope is couch');
     assert.equal(error.error, 'conflict', 'type is conflict');
-    assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
-  p.then(function(foo) {
+  assert.ok(helpers.isPromise(p), 'returns Promise');
+  p.then(function() {
     assert.ok(false, 'Promise is resolved');
   }).catch(function(error) {
     assert.ok(true, 'Promise is rejected');
     assert.equal(error.scope, 'couch', 'scope is couch');
     assert.equal(error.error, 'conflict', 'type is conflict');
+    assert.end();
   });
 });
 
@@ -65,14 +65,14 @@ it('should be able to use custom params in insert', function(assert) {
     assert.equal(error, null, 'should have stored foo');
     assert.equal(foo.ok, true, 'response should be ok');
     assert.ok(foo.rev, 'response should have rev');
-    assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
+  assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(foo) {
     assert.ok(true, 'Promise is resolved');
     assert.equal(foo.ok, true, 'response should be ok');
     assert.ok(foo.rev, 'response should have rev');
-  }).catch(function(error) {
+    assert.end();
+  }).catch(function() {
     assert.ok(false, 'Promise is rejected');
   });
 });
@@ -91,12 +91,5 @@ it('should be able to insert functions in docs', function(assert) {
       assert.end();
     });
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
-  p.then(function(foo) {
-    assert.ok(true, 'Promise is resolved');
-    assert.equal(fns.ok, true, 'response should be ok');
-    assert.ok(fns.rev, 'response should have rev');
-  }).catch(function(error) {
-    assert.ok(false, 'Promise is rejected');
-  });
+  assert.ok(helpers.isPromise(p), 'returns Promise');
 });

--- a/tests/integration/document/insert.js
+++ b/tests/integration/document/insert.js
@@ -100,19 +100,3 @@ it('should be able to insert functions in docs', function(assert) {
     assert.ok(false, 'Promise is rejected');
   });
 });
-
-it('should be able to stream an insert', function(assert) {
-  var buffer = '';
-  var foobar = db.insertAsStream({'foo': 'bar'});
-
-  function runAssertions(error, foobar) {
-    assert.equal(error, null, 'should have stored foobar');
-    assert.ok(foobar.ok, 'this is ok');
-    assert.ok(foobar.rev, 'and i got revz');
-    assert.end();
-  }
-
-  foobar.on('data', function(chunk) { buffer += chunk; });
-  foobar.on('end', function() { runAssertions(null, JSON.parse(buffer)); });
-  foobar.on('error', runAssertions);
-});

--- a/tests/integration/document/list.js
+++ b/tests/integration/document/list.js
@@ -12,16 +12,16 @@
 
 'use strict';
 
-var helpers = require('../../helpers/integration');
-var harness = helpers.harness(__filename);
-var db = harness.locals.db;
-var nano = harness.locals.nano;
-var it = harness.it;
+const helpers = require('../../helpers/integration');
+const harness = helpers.harness(__filename);
+const db = harness.locals.db;
+const nano = harness.locals.nano;
+const it = harness.it;
 
 it('should insert a bunch of items', helpers.insertThree);
 
 it('should list the three documents', function(assert) {
-  var p = db.list(function(error, docs) {
+  const p = db.list(function(error, docs) {
     assert.equal(error, null, 'should get list');
     assert.equal(docs['total_rows'], 3, 'with total three rows');
     assert.ok(docs.rows, 'and the rows themselves');
@@ -53,7 +53,7 @@ it('should be able to list using the `relax` function', function(assert) {
 });
 
 it('should be able to list with a start_key', function(assert) {
-  var p = db.list({start_key: 'c'}, function(error, docs) {
+  const p = db.list({start_key: 'c'}, function(error, docs) {
     assert.equal(error, null, 'should work');
     assert.ok(docs.rows, 'get the rows');
     assert.equal(docs.rows.length, 2, 'starts in row two');
@@ -74,7 +74,7 @@ it('should be able to list with a start_key', function(assert) {
 });
 
 it('should be able to list with a startkey', function(assert) {
-  var p = db.list({startkey: 'c'}, function(error, docs) {
+  const p = db.list({startkey: 'c'}, function(error, docs) {
     assert.equal(error, null, 'should work');
     assert.ok(docs.rows, 'get the rows');
     assert.equal(docs.rows.length, 2, 'starts in row two');
@@ -95,7 +95,7 @@ it('should be able to list with a startkey', function(assert) {
 });
 
 it('should be able to list with a endkey', function(assert) {
-  var p = db.list({endkey: 's'}, function(error, docs) {
+  const p = db.list({endkey: 's'}, function(error, docs) {
     assert.equal(error, null, 'should work');
     assert.ok(docs.rows, 'get the rows');
     assert.equal(docs.rows.length, 2, 'starts in row two');
@@ -116,7 +116,7 @@ it('should be able to list with a endkey', function(assert) {
 });
 
 it('should be able to list with a end_key', function(assert) {
-  var p = db.list({end_key: 's'}, function(error, docs) {
+  const p = db.list({end_key: 's'}, function(error, docs) {
     assert.equal(error, null, 'should work');
     assert.ok(docs.rows, 'get the rows');
     assert.equal(docs.rows.length, 2, 'starts in row two');
@@ -137,7 +137,7 @@ it('should be able to list with a end_key', function(assert) {
 });
 
 it('should be able to list as a stream', function(assert) {
-  var p = db.listAsStream(function(error) {
+  const p = db.listAsStream(function(error) {
     assert.equal(error, null, 'should work');
   });
   assert.ok(!helpers.isPromise(p), 'does not return Promise');
@@ -145,7 +145,7 @@ it('should be able to list as a stream', function(assert) {
 });
 
 it('should be able to list with params as a stream', function(assert) {
-  var p = db.listAsStream({end_key: 's'}, function(error) {
+  const p = db.listAsStream({end_key: 's'}, function(error) {
     assert.equal(error, null, 'should work');
   });
   assert.ok(!helpers.isPromise(p), 'does not return Promise');

--- a/tests/integration/document/list.js
+++ b/tests/integration/document/list.js
@@ -21,11 +21,19 @@ var it = harness.it;
 it('should insert a bunch of items', helpers.insertThree);
 
 it('should list the three documents', function(assert) {
-  db.list(function(error, docs) {
+  var p = db.list(function(error, docs) {
     assert.equal(error, null, 'should get list');
     assert.equal(docs['total_rows'], 3, 'with total three rows');
     assert.ok(docs.rows, 'and the rows themselves');
     assert.end();
+  });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(docs) {
+    assert.ok(true, 'Promise is resolved');
+    assert.equal(docs['total_rows'], 3, 'with total three rows');
+    assert.ok(docs.rows, 'and the rows themselves');
+  }).catch(function(error) {
+    assert.ok(false, 'Promise is rejected');
   });
 });
 
@@ -45,29 +53,49 @@ it('should be able to list using the `relax` function', function(assert) {
 });
 
 it('should be able to list with a start_key', function(assert) {
-  db.list({start_key: 'c'}, function(error, docs) {
+  var p = db.list({start_key: 'c'}, function(error, docs) {
     assert.equal(error, null, 'should work');
     assert.ok(docs.rows, 'get the rows');
     assert.equal(docs.rows.length, 2, 'starts in row two');
     assert.equal(docs['total_rows'], 3, 'out of three rows');
     assert.equal(docs.offset, 1, 'offset is 1');
     assert.end();
+  });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(docs) {
+    assert.ok(true, 'Promise is resolved');
+    assert.ok(docs.rows, 'get the rows');
+    assert.equal(docs.rows.length, 2, 'starts in row two');
+    assert.equal(docs['total_rows'], 3, 'out of three rows');
+    assert.equal(docs.offset, 1, 'offset is 1');
+  }).catch(function(error) {
+    assert.ok(false, 'Promise is rejected');
   });
 });
 
 it('should be able to list with a startkey', function(assert) {
-  db.list({startkey: 'c'}, function(error, docs) {
+  var p = db.list({startkey: 'c'}, function(error, docs) {
     assert.equal(error, null, 'should work');
     assert.ok(docs.rows, 'get the rows');
     assert.equal(docs.rows.length, 2, 'starts in row two');
     assert.equal(docs['total_rows'], 3, 'out of three rows');
     assert.equal(docs.offset, 1, 'offset is 1');
     assert.end();
+  });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(docs) {
+    assert.ok(true, 'Promise is resolved');
+    assert.ok(docs.rows, 'get the rows');
+    assert.equal(docs.rows.length, 2, 'starts in row two');
+    assert.equal(docs['total_rows'], 3, 'out of three rows');
+    assert.equal(docs.offset, 1, 'offset is 1');
+  }).catch(function(error) {
+    assert.ok(false, 'Promise is rejected');
   });
 });
 
 it('should be able to list with a endkey', function(assert) {
-  db.list({endkey: 's'}, function(error, docs) {
+  var p = db.list({endkey: 's'}, function(error, docs) {
     assert.equal(error, null, 'should work');
     assert.ok(docs.rows, 'get the rows');
     assert.equal(docs.rows.length, 2, 'starts in row two');
@@ -75,15 +103,35 @@ it('should be able to list with a endkey', function(assert) {
     assert.equal(docs.offset, 1, 'offset is 1');
     assert.end();
   });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(docs) {
+    assert.ok(true, 'Promise is resolved');
+    assert.ok(docs.rows, 'get the rows');
+    assert.equal(docs.rows.length, 2, 'starts in row two');
+    assert.equal(docs['total_rows'], 3, 'out of three rows');
+    assert.equal(docs.offset, 1, 'offset is 1');
+  }).catch(function(error) {
+    assert.ok(false, 'Promise is rejected');
+  });
 });
 
 it('should be able to list with a end_key', function(assert) {
-  db.list({end_key: 's'}, function(error, docs) {
+  var p = db.list({end_key: 's'}, function(error, docs) {
     assert.equal(error, null, 'should work');
     assert.ok(docs.rows, 'get the rows');
     assert.equal(docs.rows.length, 2, 'starts in row two');
     assert.equal(docs['total_rows'], 3, 'out of three rows');
     assert.equal(docs.offset, 1, 'offset is 1');
     assert.end();
+  });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(docs) {
+    assert.ok(true, 'Promise is resolved');
+    assert.ok(docs.rows, 'get the rows');
+    assert.equal(docs.rows.length, 2, 'starts in row two');
+    assert.equal(docs['total_rows'], 3, 'out of three rows');
+    assert.equal(docs.offset, 1, 'offset is 1');
+  }).catch(function(error) {
+    assert.ok(false, 'Promise is rejected');
   });
 });

--- a/tests/integration/document/list.js
+++ b/tests/integration/document/list.js
@@ -25,14 +25,14 @@ it('should list the three documents', function(assert) {
     assert.equal(error, null, 'should get list');
     assert.equal(docs['total_rows'], 3, 'with total three rows');
     assert.ok(docs.rows, 'and the rows themselves');
-    assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
+  assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(docs) {
     assert.ok(true, 'Promise is resolved');
     assert.equal(docs['total_rows'], 3, 'with total three rows');
     assert.ok(docs.rows, 'and the rows themselves');
-  }).catch(function(error) {
+    assert.end();
+  }).catch(function() {
     assert.ok(false, 'Promise is rejected');
   });
 });
@@ -59,16 +59,16 @@ it('should be able to list with a start_key', function(assert) {
     assert.equal(docs.rows.length, 2, 'starts in row two');
     assert.equal(docs['total_rows'], 3, 'out of three rows');
     assert.equal(docs.offset, 1, 'offset is 1');
-    assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
+  assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(docs) {
     assert.ok(true, 'Promise is resolved');
     assert.ok(docs.rows, 'get the rows');
     assert.equal(docs.rows.length, 2, 'starts in row two');
     assert.equal(docs['total_rows'], 3, 'out of three rows');
     assert.equal(docs.offset, 1, 'offset is 1');
-  }).catch(function(error) {
+    assert.end();
+  }).catch(function() {
     assert.ok(false, 'Promise is rejected');
   });
 });
@@ -80,16 +80,16 @@ it('should be able to list with a startkey', function(assert) {
     assert.equal(docs.rows.length, 2, 'starts in row two');
     assert.equal(docs['total_rows'], 3, 'out of three rows');
     assert.equal(docs.offset, 1, 'offset is 1');
-    assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
+  assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(docs) {
     assert.ok(true, 'Promise is resolved');
     assert.ok(docs.rows, 'get the rows');
     assert.equal(docs.rows.length, 2, 'starts in row two');
     assert.equal(docs['total_rows'], 3, 'out of three rows');
     assert.equal(docs.offset, 1, 'offset is 1');
-  }).catch(function(error) {
+    assert.end();
+  }).catch(function() {
     assert.ok(false, 'Promise is rejected');
   });
 });
@@ -101,16 +101,16 @@ it('should be able to list with a endkey', function(assert) {
     assert.equal(docs.rows.length, 2, 'starts in row two');
     assert.equal(docs['total_rows'], 3, 'out of three rows');
     assert.equal(docs.offset, 1, 'offset is 1');
-    assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
+  assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(docs) {
     assert.ok(true, 'Promise is resolved');
     assert.ok(docs.rows, 'get the rows');
     assert.equal(docs.rows.length, 2, 'starts in row two');
     assert.equal(docs['total_rows'], 3, 'out of three rows');
     assert.equal(docs.offset, 1, 'offset is 1');
-  }).catch(function(error) {
+    assert.end();
+  }).catch(function() {
     assert.ok(false, 'Promise is rejected');
   });
 });
@@ -122,16 +122,16 @@ it('should be able to list with a end_key', function(assert) {
     assert.equal(docs.rows.length, 2, 'starts in row two');
     assert.equal(docs['total_rows'], 3, 'out of three rows');
     assert.equal(docs.offset, 1, 'offset is 1');
-    assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
+  assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(docs) {
     assert.ok(true, 'Promise is resolved');
     assert.ok(docs.rows, 'get the rows');
     assert.equal(docs.rows.length, 2, 'starts in row two');
     assert.equal(docs['total_rows'], 3, 'out of three rows');
     assert.equal(docs.offset, 1, 'offset is 1');
-  }).catch(function(error) {
+    assert.end();
+  }).catch(function() {
     assert.ok(false, 'Promise is rejected');
   });
 });

--- a/tests/integration/document/list.js
+++ b/tests/integration/document/list.js
@@ -135,3 +135,19 @@ it('should be able to list with a end_key', function(assert) {
     assert.ok(false, 'Promise is rejected');
   });
 });
+
+it('should be able to list as a stream', function(assert) {
+  var p = db.listAsStream(function(error) {
+    assert.equal(error, null, 'should work');
+  });
+  assert.ok(!helpers.isPromise(p), 'does not return Promise');
+  assert.equal(p.constructor.name, 'Request', 'returns a Request');
+});
+
+it('should be able to list with params as a stream', function(assert) {
+  var p = db.listAsStream({end_key: 's'}, function(error) {
+    assert.equal(error, null, 'should work');
+  });
+  assert.ok(!helpers.isPromise(p), 'does not return Promise');
+  assert.equal(p.constructor.name, 'Request', 'returns a Request');
+});

--- a/tests/integration/document/update.js
+++ b/tests/integration/document/update.js
@@ -12,14 +12,15 @@
 
 'use strict';
 
-var helpers = require('../../helpers/integration');
-var harness = helpers.harness(__filename);
-var db = harness.locals.db;
-var it = harness.it;
-var rev;
+const helpers = require('../../helpers/integration');
+const harness = helpers.harness(__filename);
+const db = harness.locals.db;
+const it = harness.it;
+
+let rev;
 
 it('should insert one doc', function(assert) {
-  var p = db.insert({'foo': 'baz'}, 'foobar', function(error, foo) {
+  const p = db.insert({'foo': 'baz'}, 'foobar', function(error, foo) {
     assert.equal(error, null, 'stored foo');
     assert.equal(foo.ok, true, 'response ok');
     assert.ok(foo.rev, 'withs rev');
@@ -37,7 +38,7 @@ it('should insert one doc', function(assert) {
 });
 
 it('should update the document', function(assert) {
-  var p = db.insert({foo: 'bar', '_rev': rev}, 'foobar', function(error, response) {
+  const p = db.insert({foo: 'bar', '_rev': rev}, 'foobar', function(error, response) {
     assert.equal(error, null, 'should have deleted foo');
     assert.equal(response.ok, true, 'response should be ok');
   });

--- a/tests/integration/document/update.js
+++ b/tests/integration/document/update.js
@@ -16,7 +16,6 @@ var helpers = require('../../helpers/integration');
 var harness = helpers.harness(__filename);
 var db = harness.locals.db;
 var it = harness.it;
-
 var rev;
 
 it('should insert one doc', function(assert) {
@@ -25,14 +24,14 @@ it('should insert one doc', function(assert) {
     assert.equal(foo.ok, true, 'response ok');
     assert.ok(foo.rev, 'withs rev');
     rev = foo.rev;
-    assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
-  p.then(function(docs) {
+  assert.ok(helpers.isPromise(p), 'returns Promise');
+  p.then(function(foo) {
     assert.ok(true, 'Promise is resolved');
     assert.equal(foo.ok, true, 'response ok');
     assert.ok(foo.rev, 'withs rev');
-  }).catch(function(error) {
+    assert.end();
+  }).catch(function() {
     assert.ok(false, 'Promise is rejected');
   });
 });
@@ -41,13 +40,13 @@ it('should update the document', function(assert) {
   var p = db.insert({foo: 'bar', '_rev': rev}, 'foobar', function(error, response) {
     assert.equal(error, null, 'should have deleted foo');
     assert.equal(response.ok, true, 'response should be ok');
-    assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
-  p.then(function(docs) {
+  assert.ok(helpers.isPromise(p), 'returns Promise');
+  p.then(function(response) {
     assert.ok(true, 'Promise is resolved');
     assert.equal(response.ok, true, 'response should be ok');
-  }).catch(function(error) {
+    assert.end();
+  }).catch(function() {
     assert.ok(false, 'Promise is rejected');
   });
 });

--- a/tests/integration/document/update.js
+++ b/tests/integration/document/update.js
@@ -20,19 +20,34 @@ var it = harness.it;
 var rev;
 
 it('should insert one doc', function(assert) {
-  db.insert({'foo': 'baz'}, 'foobar', function(error, foo) {
+  var p = db.insert({'foo': 'baz'}, 'foobar', function(error, foo) {
     assert.equal(error, null, 'stored foo');
     assert.equal(foo.ok, true, 'response ok');
     assert.ok(foo.rev, 'withs rev');
     rev = foo.rev;
     assert.end();
   });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(docs) {
+    assert.ok(true, 'Promise is resolved');
+    assert.equal(foo.ok, true, 'response ok');
+    assert.ok(foo.rev, 'withs rev');
+  }).catch(function(error) {
+    assert.ok(false, 'Promise is rejected');
+  });
 });
 
 it('should update the document', function(assert) {
-  db.insert({foo: 'bar', '_rev': rev}, 'foobar', function(error, response) {
+  var p = db.insert({foo: 'bar', '_rev': rev}, 'foobar', function(error, response) {
     assert.equal(error, null, 'should have deleted foo');
     assert.equal(response.ok, true, 'response should be ok');
     assert.end();
+  });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(docs) {
+    assert.ok(true, 'Promise is resolved');
+    assert.equal(response.ok, true, 'response should be ok');
+  }).catch(function(error) {
+    assert.ok(false, 'Promise is rejected');
   });
 });

--- a/tests/integration/multipart/get.js
+++ b/tests/integration/multipart/get.js
@@ -32,15 +32,15 @@ it('should be able to insert a doc with att', function(assert) {
     assert.equal(foo.id, 'foobaz', 'id is foobaz');
     assert.ok(foo.rev, 'has rev');
     rev = foo.rev;
-    assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
+  assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(foo) {
     assert.ok(true, 'Promise is resolved');
     assert.equal(foo.ok, true, 'response should be ok');
     assert.equal(foo.id, 'foobaz', 'id is foobaz');
     assert.ok(foo.rev, 'has rev');
-  }).catch(function(error) {
+    assert.end();
+  }).catch(function() {
     assert.ok(false, 'Promise is rejected');
   });
 });
@@ -53,13 +53,13 @@ it('should be able to get the document with the attachment', function(assert) {
       assert.equal(headers['content-type'].split(';')[0], 'multipart/related');
     }
     assert.equal(typeof foobaz, 'object', 'foobaz should be a buffer');
-    assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
+  assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(foobaz) {
     assert.ok(true, 'Promise is resolved');
-    ssert.equal(typeof foobaz, 'object', 'foobaz should be a buffer');
-  }).catch(function(error) {
+    assert.equal(typeof foobaz, 'object', 'foobaz should be a buffer');
+    assert.end();
+  }).catch(function() {
     assert.ok(false, 'Promise is rejected');
   });
 });

--- a/tests/integration/multipart/get.js
+++ b/tests/integration/multipart/get.js
@@ -26,7 +26,7 @@ it('should be able to insert a doc with att', function(assert) {
     'content_type': 'text/plain'
   };
 
-  db.multipart.insert({'foo': 'baz'}, [att], 'foobaz', function(error, foo) {
+  var p = db.multipart.insert({'foo': 'baz'}, [att], 'foobaz', function(error, foo) {
     assert.equal(error, null, 'should have stored foobaz');
     assert.equal(foo.ok, true, 'response should be ok');
     assert.equal(foo.id, 'foobaz', 'id is foobaz');
@@ -34,10 +34,19 @@ it('should be able to insert a doc with att', function(assert) {
     rev = foo.rev;
     assert.end();
   });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(foo) {
+    assert.ok(true, 'Promise is resolved');
+    assert.equal(foo.ok, true, 'response should be ok');
+    assert.equal(foo.id, 'foobaz', 'id is foobaz');
+    assert.ok(foo.rev, 'has rev');
+  }).catch(function(error) {
+    assert.ok(false, 'Promise is rejected');
+  });
 });
 
 it('should be able to get the document with the attachment', function(assert) {
-  db.multipart.get('foobaz', function(error, foobaz, headers) {
+  var p = db.multipart.get('foobaz', function(error, foobaz, headers) {
     assert.equal(error, null, 'should get foobaz');
     if (helpers.unmocked) {
       assert.ok(headers['content-type'], 'should have content type');
@@ -45,5 +54,12 @@ it('should be able to get the document with the attachment', function(assert) {
     }
     assert.equal(typeof foobaz, 'object', 'foobaz should be a buffer');
     assert.end();
+  });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(foobaz) {
+    assert.ok(true, 'Promise is resolved');
+    ssert.equal(typeof foobaz, 'object', 'foobaz should be a buffer');
+  }).catch(function(error) {
+    assert.ok(false, 'Promise is rejected');
   });
 });

--- a/tests/integration/multipart/get.js
+++ b/tests/integration/multipart/get.js
@@ -12,21 +12,21 @@
 
 'use strict';
 
-var helpers = require('../../helpers/integration');
-var harness = helpers.harness(__filename);
-var db = harness.locals.db;
-var it = harness.it;
+const helpers = require('../../helpers/integration');
+const harness = helpers.harness(__filename);
+const db = harness.locals.db;
+const it = harness.it;
 
-var rev;
+let rev;
 
 it('should be able to insert a doc with att', function(assert) {
-  var att = {
+  const att = {
     name: 'att',
     data: 'Hello World!',
     'content_type': 'text/plain'
   };
 
-  var p = db.multipart.insert({'foo': 'baz'}, [att], 'foobaz', function(error, foo) {
+  const p = db.multipart.insert({'foo': 'baz'}, [att], 'foobaz', function(error, foo) {
     assert.equal(error, null, 'should have stored foobaz');
     assert.equal(foo.ok, true, 'response should be ok');
     assert.equal(foo.id, 'foobaz', 'id is foobaz');
@@ -46,7 +46,7 @@ it('should be able to insert a doc with att', function(assert) {
 });
 
 it('should be able to get the document with the attachment', function(assert) {
-  var p = db.multipart.get('foobaz', function(error, foobaz, headers) {
+  const p = db.multipart.get('foobaz', function(error, foobaz, headers) {
     assert.equal(error, null, 'should get foobaz');
     if (helpers.unmocked) {
       assert.ok(headers['content-type'], 'should have content type');

--- a/tests/integration/multipart/insert.js
+++ b/tests/integration/multipart/insert.js
@@ -23,11 +23,19 @@ it('should handle crazy encodings', function(assert) {
     data: 'काचं शक्नोम्यत्तुम् । नोपहिनस्ति माम् ॥',
     'content_type': 'text/plain'
   };
-  db.multipart.insert({'foo': 'bar'}, [att], 'foobar', function(error, foo) {
+  var p = db.multipart.insert({'foo': 'bar'}, [att], 'foobar', function(error, foo) {
     assert.equal(error, null, 'should have stored foo and attachment');
     assert.equal(foo.ok, true, 'response should be ok');
     assert.ok(foo.rev, 'response should have rev');
     assert.end();
+  });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(foo) {
+    assert.ok(true, 'Promise is resolved');
+    assert.equal(foo.ok, true, 'response should be ok');
+    assert.ok(foo.rev, 'response should have rev');
+  }).catch(function(error) {
+    assert.ok(false, 'Promise is rejected');
   });
 });
 
@@ -38,7 +46,7 @@ it('should test with presence of attachment', function(assert) {
     'content_type': 'text/plain'
   };
 
-  db.attachment.insert('mydoc', 'one', 'Hello World!', 'text/plain',
+  var p = db.attachment.insert('mydoc', 'one', 'Hello World!', 'text/plain',
   function(err) {
     assert.equal(err, null, 'should have stored the thingy');
     db.get('mydoc', function(_, doc) {
@@ -52,6 +60,12 @@ it('should test with presence of attachment', function(assert) {
       });
     });
   });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(foo) {
+    assert.ok(true, 'Promise is resolved');
+  }).catch(function(error) {
+    assert.ok(false, 'Promise is rejected');
+  });
 });
 
 it('should work with attachment as a buffer', function(assert) {
@@ -60,10 +74,18 @@ it('should work with attachment as a buffer', function(assert) {
     data: new Buffer('foo'),
     'content_type': 'text/plain'
   };
-  db.multipart.insert({'foo': 'bar'}, [att], 'otherdoc', function(error, foo) {
+  var p = db.multipart.insert({'foo': 'bar'}, [att], 'otherdoc', function(error, foo) {
     assert.equal(error, null, 'Should have stored foo and attachment');
     assert.equal(foo.ok, true, 'Response should be ok');
     assert.ok(foo.rev, 'Response should have rev');
     assert.end();
+  });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(foo) {
+    assert.ok(true, 'Promise is resolved');
+    assert.equal(foo.ok, true, 'response should be ok');
+    assert.ok(foo.rev, 'response should have rev');
+  }).catch(function(error) {
+    assert.ok(false, 'Promise is rejected');
   });
 });

--- a/tests/integration/multipart/insert.js
+++ b/tests/integration/multipart/insert.js
@@ -12,18 +12,18 @@
 
 'use strict';
 
-var helpers = require('../../helpers/integration');
-var harness = helpers.harness(__filename);
-var db = harness.locals.db;
-var it = harness.it;
+const helpers = require('../../helpers/integration');
+const harness = helpers.harness(__filename);
+const db = harness.locals.db;
+const it = harness.it;
 
 it('should handle crazy encodings', function(assert) {
-  var att = {
+  const att = {
     name: 'att',
     data: 'काचं शक्नोम्यत्तुम् । नोपहिनस्ति माम् ॥',
     'content_type': 'text/plain'
   };
-  var p = db.multipart.insert({'foo': 'bar'}, [att], 'foobar', function(error, foo) {
+  const p = db.multipart.insert({'foo': 'bar'}, [att], 'foobar', function(error, foo) {
     assert.equal(error, null, 'should have stored foo and attachment');
     assert.equal(foo.ok, true, 'response should be ok');
     assert.ok(foo.rev, 'response should have rev');
@@ -40,13 +40,13 @@ it('should handle crazy encodings', function(assert) {
 });
 
 it('should test with presence of attachment', function(assert) {
-  var att = {
+  const att = {
     name: 'two',
     data: 'Hello World!',
     'content_type': 'text/plain'
   };
 
-  var p = db.attachment.insert('mydoc', 'one', 'Hello World!', 'text/plain',
+  const p = db.attachment.insert('mydoc', 'one', 'Hello World!', 'text/plain',
   function(err) {
     assert.equal(err, null, 'should have stored the thingy');
     db.get('mydoc', function(_, doc) {
@@ -64,12 +64,12 @@ it('should test with presence of attachment', function(assert) {
 });
 
 it('should work with attachment as a buffer', function(assert) {
-  var att = {
+  const att = {
     name: 'att',
     data: new Buffer('foo'),
     'content_type': 'text/plain'
   };
-  var p = db.multipart.insert({'foo': 'bar'}, [att], 'otherdoc', function(error, foo) {
+  const p = db.multipart.insert({'foo': 'bar'}, [att], 'otherdoc', function(error, foo) {
     assert.equal(error, null, 'Should have stored foo and attachment');
     assert.equal(foo.ok, true, 'Response should be ok');
     assert.ok(foo.rev, 'Response should have rev');

--- a/tests/integration/multipart/insert.js
+++ b/tests/integration/multipart/insert.js
@@ -27,14 +27,14 @@ it('should handle crazy encodings', function(assert) {
     assert.equal(error, null, 'should have stored foo and attachment');
     assert.equal(foo.ok, true, 'response should be ok');
     assert.ok(foo.rev, 'response should have rev');
-    assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
+  assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(foo) {
     assert.ok(true, 'Promise is resolved');
     assert.equal(foo.ok, true, 'response should be ok');
     assert.ok(foo.rev, 'response should have rev');
-  }).catch(function(error) {
+    assert.end();
+  }).catch(function() {
     assert.ok(false, 'Promise is rejected');
   });
 });
@@ -60,12 +60,7 @@ it('should test with presence of attachment', function(assert) {
       });
     });
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
-  p.then(function(foo) {
-    assert.ok(true, 'Promise is resolved');
-  }).catch(function(error) {
-    assert.ok(false, 'Promise is rejected');
-  });
+  assert.ok(helpers.isPromise(p), 'returns Promise');
 });
 
 it('should work with attachment as a buffer', function(assert) {
@@ -78,14 +73,14 @@ it('should work with attachment as a buffer', function(assert) {
     assert.equal(error, null, 'Should have stored foo and attachment');
     assert.equal(foo.ok, true, 'Response should be ok');
     assert.ok(foo.rev, 'Response should have rev');
-    assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
+  assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(foo) {
     assert.ok(true, 'Promise is resolved');
     assert.equal(foo.ok, true, 'response should be ok');
     assert.ok(foo.rev, 'response should have rev');
-  }).catch(function(error) {
+    assert.end();
+  }).catch(function() {
     assert.ok(false, 'Promise is rejected');
   });
 });

--- a/tests/integration/shared/config.js
+++ b/tests/integration/shared/config.js
@@ -20,7 +20,7 @@ var Nano = helpers.Nano;
 var it = harness.it;
 
 it('should serve the root when no path is specified', function(assert) {
-  nano.dinosaur('', function(err, response) {
+  var p = nano.dinosaur('', function(err, response) {
     assert.equal(err, null, 'failed to get root');
     assert.ok(response.version, 'version is defined');
     nano.relax(function(err, response) {
@@ -28,6 +28,13 @@ it('should serve the root when no path is specified', function(assert) {
       assert.ok(response.version, 'had version');
       assert.end();
     });
+  });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(response) {
+    assert.ok(true, 'Promise is resolved');
+    assert.ok(response.version, 'version is defined');
+  }).catch(function(error) {
+    assert.ok(false, 'Promise is rejected');
   });
 });
 

--- a/tests/integration/shared/config.js
+++ b/tests/integration/shared/config.js
@@ -12,15 +12,15 @@
 
 'use strict';
 
-var helpers = require('../../helpers/integration');
-var harness = helpers.harness(__filename);
-var nano = harness.locals.nano;
-var Nano = helpers.Nano;
+const helpers = require('../../helpers/integration');
+const harness = helpers.harness(__filename);
+const nano = harness.locals.nano;
+const Nano = helpers.Nano;
 
-var it = harness.it;
+const it = harness.it;
 
 it('should serve the root when no path is specified', function(assert) {
-  var p = nano.dinosaur('', function(err, response) {
+  const p = nano.dinosaur('', function(err, response) {
     assert.equal(err, null, 'failed to get root');
     assert.ok(response.version, 'version is defined');
     nano.relax(function(err, response) {
@@ -39,7 +39,7 @@ it('should serve the root when no path is specified', function(assert) {
 });
 
 it('should be able to parse urls', function(assert) {
-  var baseUrl = 'http://someurl.com';
+  const baseUrl = 'http://someurl.com';
   assert.equal(
     Nano(baseUrl).config.url,
     baseUrl,
@@ -54,14 +54,6 @@ it('should be able to parse urls', function(assert) {
     Nano('http://a:b@someurl.com:5984').config.url,
     'http://a:b@someurl.com:5984',
     'with authentication');
-
-  //var withDb = Nano({
-  //  url: 'http://a:b@someurl.com:5984',
-  //  db: 'foo'
-  //})
-
-  //assert.equal(withDb.config.db, 'foo', 'should create url with db');
-  //assert.ok(withDb.attachment, 'should have an attachment');
 
   assert.equal(
     Nano('http://a:b%20c%3F@someurl.com:5984/mydb').config.url,
@@ -97,7 +89,7 @@ it('should be able to parse urls', function(assert) {
 });
 
 it('should not parse urls when parseURL flag set to false', function(assert) {
-  var url = 'http://someurl.com/path';
+  const url = 'http://someurl.com/path';
 
   assert.equal(
     Nano({
@@ -111,7 +103,7 @@ it('should not parse urls when parseURL flag set to false', function(assert) {
 });
 
 it('should accept and handle customer http headers', function(assert) {
-  var nanoWithDefaultHeaders = Nano({
+  const nanoWithDefaultHeaders = Nano({
     url: helpers.couch,
     defaultHeaders: {
       'x-custom-header': 'custom',
@@ -119,7 +111,7 @@ it('should accept and handle customer http headers', function(assert) {
     }
   });
 
-  var req = nanoWithDefaultHeaders.db.listAsStream(function(err) {
+  const req = nanoWithDefaultHeaders.db.listAsStream(function(err) {
     assert.equal(err, null, 'should list');
     assert.end();
   });
@@ -136,7 +128,7 @@ it('should accept and handle customer http headers', function(assert) {
 });
 
 it('should prevent shallow object copies', function(assert) {
-  var config = {
+  const config = {
     url: 'http://someurl.com'
   };
 

--- a/tests/integration/shared/config.js
+++ b/tests/integration/shared/config.js
@@ -112,7 +112,7 @@ it('should accept and handle customer http headers', function(assert) {
     }
   });
 
-  var req = nanoWithDefaultHeaders.db.list(function(err) {
+  var req = nanoWithDefaultHeaders.db.listAsStream(function(err) {
     assert.equal(err, null, 'should list');
     assert.end();
   });

--- a/tests/integration/shared/config.js
+++ b/tests/integration/shared/config.js
@@ -26,14 +26,14 @@ it('should serve the root when no path is specified', function(assert) {
     nano.relax(function(err, response) {
       assert.equal(err, null, 'relax');
       assert.ok(response.version, 'had version');
-      assert.end();
     });
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
+  assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(response) {
     assert.ok(true, 'Promise is resolved');
     assert.ok(response.version, 'version is defined');
-  }).catch(function(error) {
+    assert.end();
+  }).catch(function() {
     assert.ok(false, 'Promise is rejected');
   });
 });

--- a/tests/integration/shared/cookie.js
+++ b/tests/integration/shared/cookie.js
@@ -18,7 +18,6 @@ var nano = harness.locals.nano;
 var Nano = helpers.Nano;
 var it = harness.it;
 
-var admin = Nano(helpers.admin);
 var cookie;
 var server;
 
@@ -60,12 +59,12 @@ it('should be able to insert with a cookie', function(assert) {
     assert.ok(response.rev, 'response should have rev');
     assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
+  assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(response) {
     assert.ok(true, 'Promise is resolved');
     assert.equal(response.ok, true, 'response should be ok');
     assert.ok(response.rev, 'response should have rev');
-  }).catch(function(error) {
+  }).catch(function() {
     assert.ok(false, 'Promise is rejected');
   });
 });

--- a/tests/integration/shared/cookie.js
+++ b/tests/integration/shared/cookie.js
@@ -12,14 +12,14 @@
 
 'use strict';
 
-var helpers = require('../../helpers/integration');
-var harness = helpers.harness(__filename);
-var nano = harness.locals.nano;
-var Nano = helpers.Nano;
-var it = harness.it;
+const helpers = require('../../helpers/integration');
+const harness = helpers.harness(__filename);
+const nano = harness.locals.nano;
+const Nano = helpers.Nano;
+const it = harness.it;
 
-var cookie;
-var server;
+let cookie;
+let server;
 
 it('should be able to create a user', function(assert) {
   nano.relax({
@@ -51,9 +51,9 @@ it('should be able to insert with a cookie', function(assert) {
     url: helpers.couch,
     cookie: cookie
   });
-  var db = server.use('shared_cookie');
+  const db = server.use('shared_cookie');
 
-  var p = db.insert({'foo': 'baz'}, null, function(error, response) {
+  const p = db.insert({'foo': 'baz'}, null, function(error, response) {
     assert.equal(error, null, 'should have stored value');
     assert.equal(response.ok, true, 'response should be ok');
     assert.ok(response.rev, 'response should have rev');

--- a/tests/integration/shared/cookie.js
+++ b/tests/integration/shared/cookie.js
@@ -54,11 +54,19 @@ it('should be able to insert with a cookie', function(assert) {
   });
   var db = server.use('shared_cookie');
 
-  db.insert({'foo': 'baz'}, null, function(error, response) {
+  var p = db.insert({'foo': 'baz'}, null, function(error, response) {
     assert.equal(error, null, 'should have stored value');
     assert.equal(response.ok, true, 'response should be ok');
     assert.ok(response.rev, 'response should have rev');
     assert.end();
+  });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(response) {
+    assert.ok(true, 'Promise is resolved');
+    assert.equal(response.ok, true, 'response should be ok');
+    assert.ok(response.rev, 'response should have rev');
+  }).catch(function(error) {
+    assert.ok(false, 'Promise is rejected');
   });
 });
 

--- a/tests/integration/shared/error.js
+++ b/tests/integration/shared/error.js
@@ -47,13 +47,13 @@ it('should error when destroying a db that does not exist', function(assert) {
     assert.ok(error, 'an error');
     assert.ok(error.message, 'a note');
     assert.equal(error.message, 'Database does not exist.', 'is missing');
-    assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
-  p.then(function(response) {
+  assert.ok(helpers.isPromise(p), 'returns Promise');
+  p.then(function() {
     assert.ok(false, 'Promise is resolved');
   }).catch(function(error) {
     assert.ok(true, 'Promise is rejected');
     assert.equal(error.message, 'Database does not exist.', 'is missing');
+    assert.end();
   });
 });

--- a/tests/integration/shared/error.js
+++ b/tests/integration/shared/error.js
@@ -12,11 +12,11 @@
 
 'use strict';
 
-var helpers = require('../../helpers/integration');
-var harness = helpers.harness(__filename);
-var nano = harness.locals.nano;
-var Nano = helpers.Nano;
-var it = harness.it;
+const helpers = require('../../helpers/integration');
+const harness = helpers.harness(__filename);
+const nano = harness.locals.nano;
+const Nano = helpers.Nano;
+const it = harness.it;
 
 it('should throw when initialize fails', function(assert) {
   try {
@@ -35,7 +35,7 @@ it('should throw when initialize fails', function(assert) {
 });
 
 it('should be able to stream the simplest request', function(assert) {
-  var root = nano.request({stream: true});
+  const root = nano.request({stream: true});
   root.on('end', function() {
     assert.pass('request worked');
     assert.end();
@@ -43,7 +43,7 @@ it('should be able to stream the simplest request', function(assert) {
 });
 
 it('should error when destroying a db that does not exist', function(assert) {
-  var p = nano.db.destroy('say_wat_wat', function(error) {
+  const p = nano.db.destroy('say_wat_wat', function(error) {
     assert.ok(error, 'an error');
     assert.ok(error.message, 'a note');
     assert.equal(error.message, 'Database does not exist.', 'is missing');

--- a/tests/integration/shared/error.js
+++ b/tests/integration/shared/error.js
@@ -35,7 +35,7 @@ it('should throw when initialize fails', function(assert) {
 });
 
 it('should be able to stream the simplest request', function(assert) {
-  var root = nano.request();
+  var root = nano.request({stream: true});
   root.on('end', function() {
     assert.pass('request worked');
     assert.end();

--- a/tests/integration/shared/error.js
+++ b/tests/integration/shared/error.js
@@ -43,10 +43,17 @@ it('should be able to stream the simplest request', function(assert) {
 });
 
 it('should error when destroying a db that does not exist', function(assert) {
-  nano.db.destroy('say_wat_wat', function(error) {
+  var p = nano.db.destroy('say_wat_wat', function(error) {
     assert.ok(error, 'an error');
     assert.ok(error.message, 'a note');
     assert.equal(error.message, 'Database does not exist.', 'is missing');
     assert.end();
+  });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(response) {
+    assert.ok(false, 'Promise is resolved');
+  }).catch(function(error) {
+    assert.ok(true, 'Promise is rejected');
+    assert.equal(error.message, 'Database does not exist.', 'is missing');
   });
 });

--- a/tests/integration/shared/headers.js
+++ b/tests/integration/shared/headers.js
@@ -12,11 +12,11 @@
 
 'use strict';
 
-var helpers = require('../../helpers/integration');
-var harness = helpers.harness(__filename);
-var nano = harness.locals.nano;
-var db = harness.locals.db;
-var it = harness.it;
+const helpers = require('../../helpers/integration');
+const harness = helpers.harness(__filename);
+const nano = harness.locals.nano;
+const db = harness.locals.db;
+const it = harness.it;
 
 it('should get headers', function(assert) {
   db.attachment.insert('new', 'att', 'Hello', 'text/plain',

--- a/tests/integration/shared/log.js
+++ b/tests/integration/shared/log.js
@@ -12,14 +12,13 @@
 
 'use strict';
 
-var logger = require('../../../lib/logger');
-
-var helpers = require('../../helpers');
-var harness = helpers.harness(__filename);
-var it = harness.it;
+const logger = require('../../../lib/logger');
+const helpers = require('../../helpers');
+const harness = helpers.harness(__filename);
+const it = harness.it;
 
 it('should be able to instantiate a log', function(assert) {
-  var log = logger({
+  const log = logger({
     log: function(id, msg) {
       assert.equal(typeof id, 'string', 'id is set `' + id + '`');
       assert.equal(msg[0], 'testing 1234');

--- a/tests/integration/util/uuid.js
+++ b/tests/integration/util/uuid.js
@@ -19,21 +19,39 @@ var nano = helpers.nano;
 var it = harness.it;
 
 it('should generate three uuids', function(assert) {
-  nano.uuids(3, function(error, data) {
+  var p = nano.uuids(3, function(error, data) {
     assert.equal(error, null, 'should generate uuids');
     assert.ok(data, 'got response');
     assert.ok(data.uuids, 'got uuids');
     assert.equal(data.uuids.length, 3, 'got 3');
     assert.end();
   });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(data) {
+    assert.ok(true, 'Promise is resolved');
+    assert.ok(data, 'got response');
+    assert.ok(data.uuids, 'got uuids');
+    assert.equal(data.uuids.length, 3, 'got 3');
+  }).catch(function(error) {
+    assert.ok(true, 'Promise is rejected');
+  });
 });
 
 it('should generate one uuid', function(assert) {
-  nano.uuids(function(error, data) {
+  var p = nano.uuids(function(error, data) {
     assert.equal(error, null, 'should generate uuids');
     assert.ok(data, 'got response');
     assert.ok(data.uuids, 'got uuid');
     assert.equal(data.uuids.length, 1, 'got 1');
     assert.end();
+  });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(data) {
+    assert.ok(true, 'Promise is resolved');
+    assert.ok(data, 'got response');
+    assert.ok(data.uuids, 'got uuid');
+    assert.equal(data.uuids.length, 1, 'got 1');
+  }).catch(function(error) {
+    assert.ok(true, 'Promise is rejected');
   });
 });

--- a/tests/integration/util/uuid.js
+++ b/tests/integration/util/uuid.js
@@ -14,7 +14,6 @@
 
 var helpers = require('../../helpers/integration');
 var harness = helpers.harness(__filename);
-var db = harness.locals.db;
 var nano = helpers.nano;
 var it = harness.it;
 
@@ -24,15 +23,15 @@ it('should generate three uuids', function(assert) {
     assert.ok(data, 'got response');
     assert.ok(data.uuids, 'got uuids');
     assert.equal(data.uuids.length, 3, 'got 3');
-    assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
+  assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(data) {
     assert.ok(true, 'Promise is resolved');
     assert.ok(data, 'got response');
     assert.ok(data.uuids, 'got uuids');
     assert.equal(data.uuids.length, 3, 'got 3');
-  }).catch(function(error) {
+    assert.end();
+  }).catch(function() {
     assert.ok(true, 'Promise is rejected');
   });
 });
@@ -43,15 +42,15 @@ it('should generate one uuid', function(assert) {
     assert.ok(data, 'got response');
     assert.ok(data.uuids, 'got uuid');
     assert.equal(data.uuids.length, 1, 'got 1');
-    assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
+  assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(data) {
     assert.ok(true, 'Promise is resolved');
     assert.ok(data, 'got response');
     assert.ok(data.uuids, 'got uuid');
-    assert.equal(data.uuids.length, 1, 'got 1');
-  }).catch(function(error) {
+    assert.equal(data.uuids.length, 1, 'got 1');    
+    assert.end();
+  }).catch(function() {
     assert.ok(true, 'Promise is rejected');
   });
 });

--- a/tests/integration/util/uuid.js
+++ b/tests/integration/util/uuid.js
@@ -12,13 +12,13 @@
 
 'use strict';
 
-var helpers = require('../../helpers/integration');
-var harness = helpers.harness(__filename);
-var nano = helpers.nano;
-var it = harness.it;
+const helpers = require('../../helpers/integration');
+const harness = helpers.harness(__filename);
+const nano = helpers.nano;
+const it = harness.it;
 
 it('should generate three uuids', function(assert) {
-  var p = nano.uuids(3, function(error, data) {
+  const p = nano.uuids(3, function(error, data) {
     assert.equal(error, null, 'should generate uuids');
     assert.ok(data, 'got response');
     assert.ok(data.uuids, 'got uuids');
@@ -37,7 +37,7 @@ it('should generate three uuids', function(assert) {
 });
 
 it('should generate one uuid', function(assert) {
-  var p = nano.uuids(function(error, data) {
+  const p = nano.uuids(function(error, data) {
     assert.equal(error, null, 'should generate uuids');
     assert.ok(data, 'got response');
     assert.ok(data.uuids, 'got uuid');

--- a/tests/intercept/design/search.js
+++ b/tests/intercept/design/search.js
@@ -12,21 +12,21 @@
 
 'use strict';
 
-var helpers = require('../../helpers/integration');
-var harness = helpers.harness(__filename);
-var it = harness.it;
+const helpers = require('../../helpers/integration');
+const harness = helpers.harness(__filename);
+const it = harness.it;
 
-var nano = require('../../../lib/nano.js');
-var fakeRequest = function(r, callback) {
+const nano = require('../../../lib/nano.js');
+const fakeRequest = function(r, callback) {
   callback(null, { statusCode: 200 }, r);
 };
 // by passing in a fake Request object, we can intercept the request
 // and see how Nano is pre-processing the parameters
-var n = nano({url: 'http://localhost:5984', request: fakeRequest});
-var db = n.db.use('fake');
+const n = nano({url: 'http://localhost:5984', request: fakeRequest});
+const db = n.db.use('fake');
 
 it('should allow custom request object to be supplied', function(assert) {
-  var p = db.info(function(err, data) {
+  const p = db.info(function(err, data) {
       assert.equal(err, null);
       assert.equal(data.method, 'GET');
       assert.equal(typeof data.headers, 'object');
@@ -43,7 +43,7 @@ it('should allow custom request object to be supplied', function(assert) {
 });
 
 it('should encode array counts parameter', function(assert) {
-  var p = db.search('fake', 'fake', { counts: ['brand','colour'] }, function(err, data) {
+  const p = db.search('fake', 'fake', { counts: ['brand','colour'] }, function(err, data) {
       assert.equal(err, null);
       assert.equal(data.method, 'GET');
       assert.equal(typeof data.headers, 'object');
@@ -62,7 +62,7 @@ it('should encode array counts parameter', function(assert) {
 });
 
 it('should not encode string counts parameter', function(assert) {
-  var p = db.search('fake', 'fake', 
+  const p = db.search('fake', 'fake', 
                     { counts: JSON.stringify(['brand','colour']) }, 
                     function(err, data) {
       assert.equal(err, null);
@@ -84,7 +84,7 @@ it('should not encode string counts parameter', function(assert) {
 });
 
 it('should encode array drilldown parameter', function(assert) {
-  var p = db.search('fake', 'fake', { drilldown: ['colour','red'] }, function(err, data) {
+  const p = db.search('fake', 'fake', { drilldown: ['colour','red'] }, function(err, data) {
       assert.equal(err, null);
       assert.equal(data.method, 'GET');
       assert.equal(typeof data.headers, 'object');
@@ -104,7 +104,7 @@ it('should encode array drilldown parameter', function(assert) {
 });
 
 it('should not encode string drilldown parameter', function(assert) {
-  var p = db.search('fake', 'fake', 
+  const p = db.search('fake', 'fake', 
                     { drilldown: JSON.stringify(['colour','red']) }, 
                     function(err, data) {
       assert.equal(err, null);
@@ -126,7 +126,7 @@ it('should not encode string drilldown parameter', function(assert) {
 });
 
 it('should encode array group_sort parameter', function(assert) {
-  var p = db.search('fake', 'fake', 
+  const p = db.search('fake', 'fake', 
                     { group_sort: ['-foo<number>','bar<string>'] }, 
                     function(err, data) {
       assert.equal(err, null);
@@ -148,7 +148,7 @@ it('should encode array group_sort parameter', function(assert) {
 });
 
 it('should not encode string group_sort parameter', function(assert) {
-  var p = db.search('fake', 'fake', 
+  const p = db.search('fake', 'fake', 
                     { group_sort: JSON.stringify(['-foo<number>','bar<string>']) }, 
                     function(err, data) {
       assert.equal(err, null);
@@ -170,7 +170,7 @@ it('should not encode string group_sort parameter', function(assert) {
 });
 
 it('should encode object ranges parameter', function(assert) {
-  var p = db.search('fake', 'fake', 
+  const p = db.search('fake', 'fake', 
                     { ranges: {'price':'[0 TO 10]'} }, 
                     function(err, data) {
       assert.equal(err, null);
@@ -192,7 +192,7 @@ it('should encode object ranges parameter', function(assert) {
 });
 
 it('should not encode string ranges parameter', function(assert) {
-  var p = db.search('fake', 'fake', 
+  const p = db.search('fake', 'fake', 
                     { ranges: JSON.stringify({'price':'[0 TO 10]'}) }, 
                     function(err, data) {
       assert.equal(err, null);
@@ -214,7 +214,7 @@ it('should not encode string ranges parameter', function(assert) {
 });
 
 it('should encode array sort parameter', function(assert) {
-  var p = db.search('fake', 'fake', 
+  const p = db.search('fake', 'fake', 
                     { sort: ['-foo<number>','bar<string>'] }, 
                     function(err, data) {
       assert.equal(err, null);
@@ -236,7 +236,7 @@ it('should encode array sort parameter', function(assert) {
 });
 
 it('should not encode string sort parameter', function(assert) {
-  var p = db.search('fake', 'fake', 
+  const p = db.search('fake', 'fake', 
                     { sort: JSON.stringify(['-foo<number>','bar<string>']) }, 
                     function(err, data) {
       assert.equal(err, null);
@@ -258,7 +258,7 @@ it('should not encode string sort parameter', function(assert) {
 });
 
 it('should encode unencoded sort parameter', function(assert) {
-  var p = db.search('fake', 'fake', 
+  const p = db.search('fake', 'fake', 
                     { sort: '-foo<number>' }, 
                     function(err, data) {
       assert.equal(err, null);
@@ -280,7 +280,7 @@ it('should encode unencoded sort parameter', function(assert) {
 });
 
 it('should not encode encoded string sort parameter', function(assert) {
-  var p = db.search('fake', 'fake', 
+  const p = db.search('fake', 'fake', 
                     { sort: JSON.stringify('-foo<number>') }, 
                     function(err, data) {
       assert.equal(err, null);

--- a/tests/intercept/design/search.js
+++ b/tests/intercept/design/search.js
@@ -26,27 +26,43 @@ var n = nano({url: 'http://localhost:5984', request: fakeRequest});
 var db = n.db.use('fake');
 
 it('should allow custom request object to be supplied', function(assert) {
-  db.info(function(err, data) {
+  var p = db.info(function(err, data) {
       assert.equal(err, null);
       assert.equal(data.method, 'GET');
       assert.equal(typeof data.headers, 'object');
       assert.end();
+  });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(data) {
+    assert.ok(true, 'Promise is resolved');
+    assert.equal(data.method, 'GET');
+    assert.equal(typeof data.headers, 'object');
+  }).catch(function(error) {
+    assert.ok(true, 'Promise is rejected');
   });
 });
 
 it('should encode array counts parameter', function(assert) {
-  db.search('fake', 'fake', { counts: ['brand','colour'] }, function(err, data) {
+  var p = db.search('fake', 'fake', { counts: ['brand','colour'] }, function(err, data) {
       assert.equal(err, null);
       assert.equal(data.method, 'GET');
       assert.equal(typeof data.headers, 'object');
       assert.equal(typeof data.qs, 'object');
       assert.equal(data.qs.counts, JSON.stringify(['brand','colour']));
       assert.end();
+  });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(data) {
+    assert.ok(true, 'Promise is resolved');
+    assert.equal(typeof data.headers, 'object');
+    assert.equal(typeof data.qs, 'object');
+  }).catch(function(error) {
+    assert.ok(true, 'Promise is rejected');
   });
 });
 
 it('should not encode string counts parameter', function(assert) {
-  db.search('fake', 'fake', { counts: JSON.stringify(['brand','colour']) }, function(err, data) {
+  var p = db.search('fake', 'fake', { counts: JSON.stringify(['brand','colour']) }, function(err, data) {
       assert.equal(err, null);
       assert.equal(data.method, 'GET');
       assert.equal(typeof data.headers, 'object');
@@ -54,21 +70,39 @@ it('should not encode string counts parameter', function(assert) {
       assert.equal(data.qs.counts, JSON.stringify(['brand','colour']));
       assert.end();
   });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(data) {
+    assert.ok(true, 'Promise is resolved');
+    assert.equal(data.method, 'GET');
+    assert.equal(typeof data.headers, 'object');
+    assert.equal(typeof data.qs, 'object');
+  }).catch(function(error) {
+    assert.ok(true, 'Promise is rejected');
+  });
 });
 
 it('should encode array drilldown parameter', function(assert) {
-  db.search('fake', 'fake', { drilldown: ['colour','red'] }, function(err, data) {
+  var p = db.search('fake', 'fake', { drilldown: ['colour','red'] }, function(err, data) {
       assert.equal(err, null);
       assert.equal(data.method, 'GET');
       assert.equal(typeof data.headers, 'object');
       assert.equal(typeof data.qs, 'object');
       assert.equal(data.qs.drilldown, JSON.stringify(['colour','red']));
       assert.end();
+  });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(data) {
+    assert.ok(true, 'Promise is resolved');
+    assert.equal(data.method, 'GET');
+    assert.equal(typeof data.headers, 'object');
+    assert.equal(typeof data.qs, 'object');;
+  }).catch(function(error) {
+    assert.ok(true, 'Promise is rejected');
   });
 });
 
 it('should not encode string drilldown parameter', function(assert) {
-  db.search('fake', 'fake', { drilldown: JSON.stringify(['colour','red']) }, function(err, data) {
+  var p = db.search('fake', 'fake', { drilldown: JSON.stringify(['colour','red']) }, function(err, data) {
       assert.equal(err, null);
       assert.equal(data.method, 'GET');
       assert.equal(typeof data.headers, 'object');
@@ -76,21 +110,39 @@ it('should not encode string drilldown parameter', function(assert) {
       assert.equal(data.qs.drilldown, JSON.stringify(['colour','red']));
       assert.end();
   });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(data) {
+    assert.ok(true, 'Promise is resolved');
+    assert.equal(data.method, 'GET');
+    assert.equal(typeof data.headers, 'object');
+    assert.equal(typeof data.qs, 'object');;
+  }).catch(function(error) {
+    assert.ok(true, 'Promise is rejected');
+  });
 });
 
 it('should encode array group_sort parameter', function(assert) {
-  db.search('fake', 'fake', { group_sort: ['-foo<number>','bar<string>'] }, function(err, data) {
+  var p = db.search('fake', 'fake', { group_sort: ['-foo<number>','bar<string>'] }, function(err, data) {
       assert.equal(err, null);
       assert.equal(data.method, 'GET');
       assert.equal(typeof data.headers, 'object');
       assert.equal(typeof data.qs, 'object');
       assert.equal(data.qs.group_sort, JSON.stringify(['-foo<number>','bar<string>']));
       assert.end();
+  });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(data) {
+    assert.ok(true, 'Promise is resolved');
+    assert.equal(data.method, 'GET');
+    assert.equal(typeof data.headers, 'object');
+    assert.equal(typeof data.qs, 'object');;
+  }).catch(function(error) {
+    assert.ok(true, 'Promise is rejected');
   });
 });
 
 it('should not encode string group_sort parameter', function(assert) {
-  db.search('fake', 'fake', { group_sort: JSON.stringify(['-foo<number>','bar<string>']) }, function(err, data) {
+  var p = db.search('fake', 'fake', { group_sort: JSON.stringify(['-foo<number>','bar<string>']) }, function(err, data) {
       assert.equal(err, null);
       assert.equal(data.method, 'GET');
       assert.equal(typeof data.headers, 'object');
@@ -98,21 +150,39 @@ it('should not encode string group_sort parameter', function(assert) {
       assert.equal(data.qs.group_sort, JSON.stringify(['-foo<number>','bar<string>']));
       assert.end();
   });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(data) {
+    assert.ok(true, 'Promise is resolved');
+    assert.equal(data.method, 'GET');
+    assert.equal(typeof data.headers, 'object');
+    assert.equal(typeof data.qs, 'object');;
+  }).catch(function(error) {
+    assert.ok(true, 'Promise is rejected');
+  });
 });
 
 it('should encode object ranges parameter', function(assert) {
-  db.search('fake', 'fake', { ranges: {'price':'[0 TO 10]'} }, function(err, data) {
+  var p = db.search('fake', 'fake', { ranges: {'price':'[0 TO 10]'} }, function(err, data) {
       assert.equal(err, null);
       assert.equal(data.method, 'GET');
       assert.equal(typeof data.headers, 'object');
       assert.equal(typeof data.qs, 'object');
       assert.equal(data.qs.ranges, JSON.stringify({'price':'[0 TO 10]'}));
       assert.end();
+  });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(data) {
+    assert.ok(true, 'Promise is resolved');
+    assert.equal(data.method, 'GET');
+    assert.equal(typeof data.headers, 'object');
+    assert.equal(typeof data.qs, 'object');;
+  }).catch(function(error) {
+    assert.ok(true, 'Promise is rejected');
   });
 });
 
 it('should not encode string ranges parameter', function(assert) {
-  db.search('fake', 'fake', { ranges: JSON.stringify({'price':'[0 TO 10]'}) }, function(err, data) {
+  var p = db.search('fake', 'fake', { ranges: JSON.stringify({'price':'[0 TO 10]'}) }, function(err, data) {
       assert.equal(err, null);
       assert.equal(data.method, 'GET');
       assert.equal(typeof data.headers, 'object');
@@ -120,21 +190,39 @@ it('should not encode string ranges parameter', function(assert) {
       assert.equal(data.qs.ranges, JSON.stringify({'price':'[0 TO 10]'}));
       assert.end();
   });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(data) {
+    assert.ok(true, 'Promise is resolved');
+    assert.equal(data.method, 'GET');
+    assert.equal(typeof data.headers, 'object');
+    assert.equal(typeof data.qs, 'object');;
+  }).catch(function(error) {
+    assert.ok(true, 'Promise is rejected');
+  });
 });
 
 it('should encode array sort parameter', function(assert) {
-  db.search('fake', 'fake', { sort: ['-foo<number>','bar<string>'] }, function(err, data) {
+  var p = db.search('fake', 'fake', { sort: ['-foo<number>','bar<string>'] }, function(err, data) {
       assert.equal(err, null);
       assert.equal(data.method, 'GET');
       assert.equal(typeof data.headers, 'object');
       assert.equal(typeof data.qs, 'object');
       assert.equal(data.qs.sort, JSON.stringify(['-foo<number>','bar<string>']));
       assert.end();
+  });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(data) {
+    assert.ok(true, 'Promise is resolved');
+    assert.equal(data.method, 'GET');
+    assert.equal(typeof data.headers, 'object');
+    assert.equal(typeof data.qs, 'object');;
+  }).catch(function(error) {
+    assert.ok(true, 'Promise is rejected');
   });
 });
 
 it('should not encode string sort parameter', function(assert) {
-  db.search('fake', 'fake', { sort: JSON.stringify(['-foo<number>','bar<string>']) }, function(err, data) {
+  var p = db.search('fake', 'fake', { sort: JSON.stringify(['-foo<number>','bar<string>']) }, function(err, data) {
       assert.equal(err, null);
       assert.equal(data.method, 'GET');
       assert.equal(typeof data.headers, 'object');
@@ -142,10 +230,19 @@ it('should not encode string sort parameter', function(assert) {
       assert.equal(data.qs.sort, JSON.stringify(['-foo<number>','bar<string>']));
       assert.end();
   });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(data) {
+    assert.ok(true, 'Promise is resolved');
+    assert.equal(data.method, 'GET');
+    assert.equal(typeof data.headers, 'object');
+    assert.equal(typeof data.qs, 'object');;
+  }).catch(function(error) {
+    assert.ok(true, 'Promise is rejected');
+  });
 });
 
 it('should encode unencoded sort parameter', function(assert) {
-  db.search('fake', 'fake', { sort: '-foo<number>' }, function(err, data) {
+  var p = db.search('fake', 'fake', { sort: '-foo<number>' }, function(err, data) {
       assert.equal(err, null);
       assert.equal(data.method, 'GET');
       assert.equal(typeof data.headers, 'object');
@@ -153,16 +250,34 @@ it('should encode unencoded sort parameter', function(assert) {
       assert.equal(data.qs.sort, JSON.stringify('-foo<number>'));
       assert.end();
   });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(data) {
+    assert.ok(true, 'Promise is resolved');
+    assert.equal(data.method, 'GET');
+    assert.equal(typeof data.headers, 'object');
+    assert.equal(typeof data.qs, 'object');;
+  }).catch(function(error) {
+    assert.ok(true, 'Promise is rejected');
+  });
 });
 
 it('should not encode encoded string sort parameter', function(assert) {
-  db.search('fake', 'fake', { sort: JSON.stringify('-foo<number>') }, function(err, data) {
+  var p = db.search('fake', 'fake', { sort: JSON.stringify('-foo<number>') }, function(err, data) {
       assert.equal(err, null);
       assert.equal(data.method, 'GET');
       assert.equal(typeof data.headers, 'object');
       assert.equal(typeof data.qs, 'object');
       assert.equal(data.qs.sort, JSON.stringify('-foo<number>'));
       assert.end();
+  });
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function(data) {
+    assert.ok(true, 'Promise is resolved');
+    assert.equal(data.method, 'GET');
+    assert.equal(typeof data.headers, 'object');
+    assert.equal(typeof data.qs, 'object');;
+  }).catch(function(error) {
+    assert.ok(true, 'Promise is rejected');
   });
 });
 

--- a/tests/intercept/design/search.js
+++ b/tests/intercept/design/search.js
@@ -30,14 +30,14 @@ it('should allow custom request object to be supplied', function(assert) {
       assert.equal(err, null);
       assert.equal(data.method, 'GET');
       assert.equal(typeof data.headers, 'object');
-      assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
+  assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(data) {
     assert.ok(true, 'Promise is resolved');
     assert.equal(data.method, 'GET');
     assert.equal(typeof data.headers, 'object');
-  }).catch(function(error) {
+    assert.end();
+  }).catch(function() {
     assert.ok(true, 'Promise is rejected');
   });
 });
@@ -49,34 +49,36 @@ it('should encode array counts parameter', function(assert) {
       assert.equal(typeof data.headers, 'object');
       assert.equal(typeof data.qs, 'object');
       assert.equal(data.qs.counts, JSON.stringify(['brand','colour']));
-      assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
+  assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(data) {
     assert.ok(true, 'Promise is resolved');
     assert.equal(typeof data.headers, 'object');
     assert.equal(typeof data.qs, 'object');
-  }).catch(function(error) {
+    assert.end();
+  }).catch(function() {
     assert.ok(true, 'Promise is rejected');
   });
 });
 
 it('should not encode string counts parameter', function(assert) {
-  var p = db.search('fake', 'fake', { counts: JSON.stringify(['brand','colour']) }, function(err, data) {
+  var p = db.search('fake', 'fake', 
+                    { counts: JSON.stringify(['brand','colour']) }, 
+                    function(err, data) {
       assert.equal(err, null);
       assert.equal(data.method, 'GET');
       assert.equal(typeof data.headers, 'object');
       assert.equal(typeof data.qs, 'object');
       assert.equal(data.qs.counts, JSON.stringify(['brand','colour']));
-      assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
+  assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(data) {
     assert.ok(true, 'Promise is resolved');
     assert.equal(data.method, 'GET');
     assert.equal(typeof data.headers, 'object');
     assert.equal(typeof data.qs, 'object');
-  }).catch(function(error) {
+    assert.end();
+  }).catch(function() {
     assert.ok(true, 'Promise is rejected');
   });
 });
@@ -88,198 +90,213 @@ it('should encode array drilldown parameter', function(assert) {
       assert.equal(typeof data.headers, 'object');
       assert.equal(typeof data.qs, 'object');
       assert.equal(data.qs.drilldown, JSON.stringify(['colour','red']));
-      assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
+  assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(data) {
     assert.ok(true, 'Promise is resolved');
     assert.equal(data.method, 'GET');
     assert.equal(typeof data.headers, 'object');
-    assert.equal(typeof data.qs, 'object');;
-  }).catch(function(error) {
+    assert.equal(typeof data.qs, 'object');
+    assert.end();
+  }).catch(function() {
     assert.ok(true, 'Promise is rejected');
   });
 });
 
 it('should not encode string drilldown parameter', function(assert) {
-  var p = db.search('fake', 'fake', { drilldown: JSON.stringify(['colour','red']) }, function(err, data) {
+  var p = db.search('fake', 'fake', 
+                    { drilldown: JSON.stringify(['colour','red']) }, 
+                    function(err, data) {
       assert.equal(err, null);
       assert.equal(data.method, 'GET');
       assert.equal(typeof data.headers, 'object');
       assert.equal(typeof data.qs, 'object');
       assert.equal(data.qs.drilldown, JSON.stringify(['colour','red']));
-      assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
+  assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(data) {
     assert.ok(true, 'Promise is resolved');
     assert.equal(data.method, 'GET');
     assert.equal(typeof data.headers, 'object');
-    assert.equal(typeof data.qs, 'object');;
-  }).catch(function(error) {
+    assert.equal(typeof data.qs, 'object');
+    assert.end();
+  }).catch(function() {
     assert.ok(true, 'Promise is rejected');
   });
 });
 
 it('should encode array group_sort parameter', function(assert) {
-  var p = db.search('fake', 'fake', { group_sort: ['-foo<number>','bar<string>'] }, function(err, data) {
+  var p = db.search('fake', 'fake', 
+                    { group_sort: ['-foo<number>','bar<string>'] }, 
+                    function(err, data) {
       assert.equal(err, null);
       assert.equal(data.method, 'GET');
       assert.equal(typeof data.headers, 'object');
       assert.equal(typeof data.qs, 'object');
       assert.equal(data.qs.group_sort, JSON.stringify(['-foo<number>','bar<string>']));
-      assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
+  assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(data) {
     assert.ok(true, 'Promise is resolved');
     assert.equal(data.method, 'GET');
     assert.equal(typeof data.headers, 'object');
-    assert.equal(typeof data.qs, 'object');;
-  }).catch(function(error) {
+    assert.equal(typeof data.qs, 'object');
+    assert.end();
+  }).catch(function() {
     assert.ok(true, 'Promise is rejected');
   });
 });
 
 it('should not encode string group_sort parameter', function(assert) {
-  var p = db.search('fake', 'fake', { group_sort: JSON.stringify(['-foo<number>','bar<string>']) }, function(err, data) {
+  var p = db.search('fake', 'fake', 
+                    { group_sort: JSON.stringify(['-foo<number>','bar<string>']) }, 
+                    function(err, data) {
       assert.equal(err, null);
       assert.equal(data.method, 'GET');
       assert.equal(typeof data.headers, 'object');
       assert.equal(typeof data.qs, 'object');
       assert.equal(data.qs.group_sort, JSON.stringify(['-foo<number>','bar<string>']));
-      assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
+  assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(data) {
     assert.ok(true, 'Promise is resolved');
     assert.equal(data.method, 'GET');
     assert.equal(typeof data.headers, 'object');
-    assert.equal(typeof data.qs, 'object');;
-  }).catch(function(error) {
+    assert.equal(typeof data.qs, 'object');
+    assert.end();
+  }).catch(function() {
     assert.ok(true, 'Promise is rejected');
   });
 });
 
 it('should encode object ranges parameter', function(assert) {
-  var p = db.search('fake', 'fake', { ranges: {'price':'[0 TO 10]'} }, function(err, data) {
+  var p = db.search('fake', 'fake', 
+                    { ranges: {'price':'[0 TO 10]'} }, 
+                    function(err, data) {
       assert.equal(err, null);
       assert.equal(data.method, 'GET');
       assert.equal(typeof data.headers, 'object');
       assert.equal(typeof data.qs, 'object');
       assert.equal(data.qs.ranges, JSON.stringify({'price':'[0 TO 10]'}));
-      assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
+  assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(data) {
     assert.ok(true, 'Promise is resolved');
     assert.equal(data.method, 'GET');
     assert.equal(typeof data.headers, 'object');
-    assert.equal(typeof data.qs, 'object');;
-  }).catch(function(error) {
+    assert.equal(typeof data.qs, 'object');
+    assert.end();
+  }).catch(function() {
     assert.ok(true, 'Promise is rejected');
   });
 });
 
 it('should not encode string ranges parameter', function(assert) {
-  var p = db.search('fake', 'fake', { ranges: JSON.stringify({'price':'[0 TO 10]'}) }, function(err, data) {
+  var p = db.search('fake', 'fake', 
+                    { ranges: JSON.stringify({'price':'[0 TO 10]'}) }, 
+                    function(err, data) {
       assert.equal(err, null);
       assert.equal(data.method, 'GET');
       assert.equal(typeof data.headers, 'object');
       assert.equal(typeof data.qs, 'object');
       assert.equal(data.qs.ranges, JSON.stringify({'price':'[0 TO 10]'}));
-      assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
+  assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(data) {
     assert.ok(true, 'Promise is resolved');
     assert.equal(data.method, 'GET');
     assert.equal(typeof data.headers, 'object');
-    assert.equal(typeof data.qs, 'object');;
-  }).catch(function(error) {
+    assert.equal(typeof data.qs, 'object');
+    assert.end();
+  }).catch(function() {
     assert.ok(true, 'Promise is rejected');
   });
 });
 
 it('should encode array sort parameter', function(assert) {
-  var p = db.search('fake', 'fake', { sort: ['-foo<number>','bar<string>'] }, function(err, data) {
+  var p = db.search('fake', 'fake', 
+                    { sort: ['-foo<number>','bar<string>'] }, 
+                    function(err, data) {
       assert.equal(err, null);
       assert.equal(data.method, 'GET');
       assert.equal(typeof data.headers, 'object');
       assert.equal(typeof data.qs, 'object');
       assert.equal(data.qs.sort, JSON.stringify(['-foo<number>','bar<string>']));
-      assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
+  assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(data) {
     assert.ok(true, 'Promise is resolved');
     assert.equal(data.method, 'GET');
     assert.equal(typeof data.headers, 'object');
-    assert.equal(typeof data.qs, 'object');;
-  }).catch(function(error) {
+    assert.equal(typeof data.qs, 'object');
+    assert.end();
+  }).catch(function() {
     assert.ok(true, 'Promise is rejected');
   });
 });
 
 it('should not encode string sort parameter', function(assert) {
-  var p = db.search('fake', 'fake', { sort: JSON.stringify(['-foo<number>','bar<string>']) }, function(err, data) {
+  var p = db.search('fake', 'fake', 
+                    { sort: JSON.stringify(['-foo<number>','bar<string>']) }, 
+                    function(err, data) {
       assert.equal(err, null);
       assert.equal(data.method, 'GET');
       assert.equal(typeof data.headers, 'object');
       assert.equal(typeof data.qs, 'object');
       assert.equal(data.qs.sort, JSON.stringify(['-foo<number>','bar<string>']));
-      assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
+  assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(data) {
     assert.ok(true, 'Promise is resolved');
     assert.equal(data.method, 'GET');
     assert.equal(typeof data.headers, 'object');
-    assert.equal(typeof data.qs, 'object');;
-  }).catch(function(error) {
+    assert.equal(typeof data.qs, 'object');
+    assert.end();
+  }).catch(function() {
     assert.ok(true, 'Promise is rejected');
   });
 });
 
 it('should encode unencoded sort parameter', function(assert) {
-  var p = db.search('fake', 'fake', { sort: '-foo<number>' }, function(err, data) {
+  var p = db.search('fake', 'fake', 
+                    { sort: '-foo<number>' }, 
+                    function(err, data) {
       assert.equal(err, null);
       assert.equal(data.method, 'GET');
       assert.equal(typeof data.headers, 'object');
       assert.equal(typeof data.qs, 'object');
       assert.equal(data.qs.sort, JSON.stringify('-foo<number>'));
-      assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
+  assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(data) {
     assert.ok(true, 'Promise is resolved');
     assert.equal(data.method, 'GET');
     assert.equal(typeof data.headers, 'object');
-    assert.equal(typeof data.qs, 'object');;
-  }).catch(function(error) {
+    assert.equal(typeof data.qs, 'object');
+    assert.end();
+  }).catch(function() {
     assert.ok(true, 'Promise is rejected');
   });
 });
 
 it('should not encode encoded string sort parameter', function(assert) {
-  var p = db.search('fake', 'fake', { sort: JSON.stringify('-foo<number>') }, function(err, data) {
+  var p = db.search('fake', 'fake', 
+                    { sort: JSON.stringify('-foo<number>') }, 
+                    function(err, data) {
       assert.equal(err, null);
       assert.equal(data.method, 'GET');
       assert.equal(typeof data.headers, 'object');
       assert.equal(typeof data.qs, 'object');
       assert.equal(data.qs.sort, JSON.stringify('-foo<number>'));
-      assert.end();
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise')
+  assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(data) {
     assert.ok(true, 'Promise is resolved');
     assert.equal(data.method, 'GET');
     assert.equal(typeof data.headers, 'object');
-    assert.equal(typeof data.qs, 'object');;
-  }).catch(function(error) {
+    assert.equal(typeof data.qs, 'object');
+    assert.end();
+  }).catch(function() {
     assert.ok(true, 'Promise is rejected');
   });
 });
-
-
-console.log('I AM HERE');

--- a/tests/intercept/design/search.js
+++ b/tests/intercept/design/search.js
@@ -300,3 +300,16 @@ it('should not encode encoded string sort parameter', function(assert) {
     assert.ok(true, 'Promise is rejected');
   });
 });
+
+it('should allow search results to be streamed', function(assert) {
+  db.searchAsStream('fake', 'fake', 
+                    { q: 'foo:bar' }, 
+                    function(err, data) {
+      assert.equal(err, null);
+      assert.equal(data.method, 'GET');
+      assert.equal(typeof data.headers, 'object');
+      assert.equal(typeof data.qs, 'object');
+      assert.equal(data.qs.q, 'foo:bar');
+      assert.end();
+  });
+});

--- a/tests/unit/attachment/destroy.js
+++ b/tests/unit/attachment/destroy.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-var destroyAttachment = require('../../helpers/unit').unit([
+const destroyAttachment = require('../../helpers/unit').unit([
   'attachment',
   'destroy'
 ]);

--- a/tests/unit/attachment/get.js
+++ b/tests/unit/attachment/get.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-var getAttachment = require('../../helpers/unit').unit([
+const getAttachment = require('../../helpers/unit').unit([
   'attachment',
   'get'
 ]);

--- a/tests/unit/attachment/insert.js
+++ b/tests/unit/attachment/insert.js
@@ -12,10 +12,10 @@
 
 'use strict';
 
-var helpers = require('../../helpers/unit');
-var insertAttachment = helpers.unit(['attachment', 'insert']);
+const helpers = require('../../helpers/unit');
+const insertAttachment = helpers.unit(['attachment', 'insert']);
 
-var buffer = new Buffer(helpers.pixel, 'base64');
+const buffer = new Buffer(helpers.pixel, 'base64');
 
 insertAttachment('pixels', 'pixel.bmp', buffer, 'image/bmp', {
   body: buffer,

--- a/tests/unit/database/changes.js
+++ b/tests/unit/database/changes.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-var changesDatabase = require('../../helpers/unit').unit([
+const changesDatabase = require('../../helpers/unit').unit([
   'database',
   'changes'
 ]);

--- a/tests/unit/database/compact.js
+++ b/tests/unit/database/compact.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-var compactDatabase = require('../../helpers/unit').unit([
+const compactDatabase = require('../../helpers/unit').unit([
   'database',
   'compact'
 ]);

--- a/tests/unit/database/create.js
+++ b/tests/unit/database/create.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-var createDatabase = require('../../helpers/unit').unit([
+const createDatabase = require('../../helpers/unit').unit([
   'database',
   'create'
 ]);

--- a/tests/unit/database/destroy.js
+++ b/tests/unit/database/destroy.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-var destroyDatabase = require('../../helpers/unit').unit([
+const destroyDatabase = require('../../helpers/unit').unit([
   'database',
   'destroy'
 ]);

--- a/tests/unit/database/follow.js
+++ b/tests/unit/database/follow.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-var followDatabase = require('../../helpers/unit').unit([
+const followDatabase = require('../../helpers/unit').unit([
   'database',
   'follow'
 ]);

--- a/tests/unit/database/get.js
+++ b/tests/unit/database/get.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-var getDatabase = require('../../helpers/unit').unit([
+const getDatabase = require('../../helpers/unit').unit([
   'database',
   'get'
 ]);

--- a/tests/unit/database/list.js
+++ b/tests/unit/database/list.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-var listDatabases = require('../../helpers/unit').unit([
+const listDatabases = require('../../helpers/unit').unit([
   'database',
   'list'
 ]);

--- a/tests/unit/database/replicate.js
+++ b/tests/unit/database/replicate.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-var replicateDatabase = require('../../helpers/unit').unit([
+const replicateDatabase = require('../../helpers/unit').unit([
   'database',
   'replicate'
 ]);

--- a/tests/unit/database/replicator.js
+++ b/tests/unit/database/replicator.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-var replicator = require('../../helpers/unit').unit([
+const replicator = require('../../helpers/unit').unit([
   'database',
   'replicator'
 ]);

--- a/tests/unit/database/updates.js
+++ b/tests/unit/database/updates.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-var updatesDatabase = require('../../helpers/unit').unit([
+const updatesDatabase = require('../../helpers/unit').unit([
   'database',
   'updates'
 ]);

--- a/tests/unit/design/atomic.js
+++ b/tests/unit/design/atomic.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-var atomicDesign = require('../../helpers/unit').unit([
+const atomicDesign = require('../../helpers/unit').unit([
   'view',
   'atomic'
 ]);

--- a/tests/unit/design/compact.js
+++ b/tests/unit/design/compact.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-var compactDesign = require('../../helpers/unit').unit([
+const compactDesign = require('../../helpers/unit').unit([
   'view',
   'compact'
 ]);

--- a/tests/unit/design/find.js
+++ b/tests/unit/design/find.js
@@ -11,7 +11,7 @@
 // the License.
 
 'use strict';
-var findDesign = require('../../helpers/unit').unit([
+const findDesign = require('../../helpers/unit').unit([
   'find',
   'find'
 ]);

--- a/tests/unit/design/list.js
+++ b/tests/unit/design/list.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-var listDesign = require('../../helpers/unit').unit([
+const listDesign = require('../../helpers/unit').unit([
   'view',
   'viewWithList'
 ]);

--- a/tests/unit/design/search.js
+++ b/tests/unit/design/search.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-var searchDesign = require('../../helpers/unit').unit([
+const searchDesign = require('../../helpers/unit').unit([
   'view',
   'search'
 ]);

--- a/tests/unit/design/show.js
+++ b/tests/unit/design/show.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-var showDesign = require('../../helpers/unit').unit([
+const showDesign = require('../../helpers/unit').unit([
   'view',
   'show'
 ]);

--- a/tests/unit/design/spatial.js
+++ b/tests/unit/design/spatial.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-var geoDesign = require('../../helpers/unit').unit([
+const geoDesign = require('../../helpers/unit').unit([
   'view',
   'spatial'
 ]);

--- a/tests/unit/design/view.js
+++ b/tests/unit/design/view.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-var viewDesign = require('../../helpers/unit').unit([
+const viewDesign = require('../../helpers/unit').unit([
   'view',
   'view'
 ]);

--- a/tests/unit/document/bulk.js
+++ b/tests/unit/document/bulk.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-var bulkDocument = require('../../helpers/unit').unit([
+const bulkDocument = require('../../helpers/unit').unit([
   'document',
   'bulk'
 ]);

--- a/tests/unit/document/copy.js
+++ b/tests/unit/document/copy.js
@@ -12,12 +12,12 @@
 
 'use strict';
 
-var copyDocument = require('../../helpers/unit').unit([
+const copyDocument = require('../../helpers/unit').unit([
   'document',
   'copy'
 ]);
 
-var copyDocumentFail = require('../../helpers/unit').unit([
+const copyDocumentFail = require('../../helpers/unit').unit([
   'document',
   'copy'
 ], new Error('OMG This sucks'));

--- a/tests/unit/document/get.js
+++ b/tests/unit/document/get.js
@@ -16,8 +16,8 @@ var helpers = require('../../helpers/unit');
 var test  = require('tape');
 var debug = require('debug')('nano/tests/unit/shared/error');
 
-var cli = helpers.mockClientDb(debug)
-var db = cli.use('foo')
+var cli = helpers.mockClientDb(debug);
+var db = cli.use('foo');
 
 test('it should not return db info if docName undefined', function(assert) {
   db.get(undefined, function(err) {

--- a/tests/unit/document/get.js
+++ b/tests/unit/document/get.js
@@ -12,12 +12,12 @@
 
 'use strict';
 
-var helpers = require('../../helpers/unit');
-var test  = require('tape');
-var debug = require('debug')('nano/tests/unit/shared/error');
+const helpers = require('../../helpers/unit');
+const test  = require('tape');
+const debug = require('debug')('nano/tests/unit/shared/error');
 
-var cli = helpers.mockClientDb(debug);
-var db = cli.use('foo');
+const cli = helpers.mockClientDb(debug);
+const db = cli.use('foo');
 
 test('it should not return db info if docName undefined', function(assert) {
   db.get(undefined, function(err) {

--- a/tests/unit/multipart/get.js
+++ b/tests/unit/multipart/get.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-var getMultipart = require('../../helpers/unit').unit([
+const getMultipart = require('../../helpers/unit').unit([
   'multipart',
   'get'
 ]);

--- a/tests/unit/multipart/insert.js
+++ b/tests/unit/multipart/insert.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-var insertMultipart = require('../../helpers/unit').unit([
+const insertMultipart = require('../../helpers/unit').unit([
   'multipart',
   'insert'
 ]);

--- a/tests/unit/shared/error.js
+++ b/tests/unit/shared/error.js
@@ -12,17 +12,17 @@
 
 'use strict';
 
-var helpers = require('../../helpers/unit');
-var test  = require('tape');
-var debug = require('debug')('nano/tests/unit/shared/error');
+const helpers = require('../../helpers/unit');
+const test  = require('tape');
+const debug = require('debug')('nano/tests/unit/shared/error');
 
-var cli = helpers.mockClientFail(debug);
-var cli2 = helpers.mockClientUnparsedError(debug);
-var cli3 = helpers.mockClientUnparsedError(debug, JSON.stringify({
+const cli = helpers.mockClientFail(debug);
+const cli2 = helpers.mockClientUnparsedError(debug);
+const cli3 = helpers.mockClientUnparsedError(debug, JSON.stringify({
   error: 'not a reason'
 }));
 
-var cli4 = helpers.mockClientUnparsedError(debug, JSON.stringify({
+const cli4 = helpers.mockClientUnparsedError(debug, JSON.stringify({
   stack: new Error('foo').stack
 }));
 
@@ -49,7 +49,7 @@ test('should be capable of using `error`', function(assert) {
 
 test('should remove cloudant stacktraces', function(assert) {
   cli4.relax({}, function(err) {
-    var msg = err.stack.split('\n')[0];
+    const msg = err.stack.split('\n')[0];
     assert.notEqual(msg, 'Error: foo');
     assert.equal(msg, 'Error: Unspecified error');
     assert.end();

--- a/tests/unit/shared/follow-updates.js
+++ b/tests/unit/shared/follow-updates.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-var followUpdates = require('../../helpers/unit').unit([
+const followUpdates = require('../../helpers/unit').unit([
   'server',
   'followUpdates'
 ]);

--- a/tests/unit/shared/jar.js
+++ b/tests/unit/shared/jar.js
@@ -12,11 +12,11 @@
 
 'use strict';
 
-var helpers = require('../../helpers/unit');
-var test  = require('tape');
-var debug = require('debug')('nano/tests/unit/shared/jar');
+const helpers = require('../../helpers/unit');
+const test  = require('tape');
+const debug = require('debug')('nano/tests/unit/shared/jar');
 
-var cli = helpers.mockClientJar(debug);
+const cli = helpers.mockClientJar(debug);
 
 test('it should be able to set a jar box', function(assert) {
   assert.equal(cli.config.jar, 'is set');


### PR DESCRIPTION
## Overview

Aimed at a v7.x release of Nano, this PR makes Nano return a _Promise_ instead of a _Request_ object as its return value. See https://github.com/apache/couchdb-nano/issues/98. This brings Nano into the modern world without breaking code that uses the callback style. It only breaks code that relied on the events emitted from the Request object or that piped the stream to another stream.

Work done in this PR:

- most functions return a _Promise_
- new ...AsStream| functions are availble for operations that return lots of data. These return a _Request_ object
- test suite updated
- README changed to reflect the new API
- TypeScript definitions updated too
- written `migration_6_to_7` guide

## Testing recommendations

The tests have been updated to reflect the change. Instantiate a Nano instance and most operations will return a _Promise_:

```js
var nano = require('.')
var n = nano('http://localhost:5984')
var db = n.db.use('animals')
db.list({start_key:'cat1',end_key:'cat4'})
  .then(console.log)
  .catch(console.error)
```

## GitHub issue number

https://github.com/apache/couchdb-nano/issues/98

## Related Pull Requests

https://github.com/apache/couchdb-nano/pull/88

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [x] Documentation reflects the changes;
