### PR TITLE
Prevent callback users seeing Promise rejections

### DIFF
--- a/README.md
+++ b/README.md
@@ -963,10 +963,10 @@ alice.findAsStream(q).pipe(process.stdout);
 
 ## using cookie authentication
 
-Nano supports making requests using CouchDB's [cookie authentication](http://guide.couchdb.org/editions/1/en/security.html#cookies) functionality. Call `nano.auth` first to get a session cookie. As we initialise `nano` with `requestDefaults: { jar: true }`, we are asking the `request` library to behave like a web browser - remembering any cookies that the server sets and sending them back in subsequent requests:
+Nano supports making requests using CouchDB's [cookie authentication](http://guide.couchdb.org/editions/1/en/security.html#cookies) functionality. Call `nano.auth` first to get a session cookie. Nano will behave like a web browser, remembering your session cookie and refreshing it if a new one is received in a future HTTP response.
 
 ```js
-const nano = require('nano')({ url: 'http://localhost:5984', requestDefaults: { jar: true }}),
+const nano = require('nano')('http://localhost:5984'),
   username = 'user',
   userpass = 'pass',
   db = nano.db.use('mydb');

--- a/lib/nano.js
+++ b/lib/nano.js
@@ -28,6 +28,7 @@ function getCallback (opts, callback) {
     callback = opts;
     opts = {};
   }
+  opts = opts || {};
   return {
     opts,
     callback
@@ -48,7 +49,7 @@ module.exports = exports = nano = function dbScope(cfg) {
   cfg = Object.assign({}, cfg);
 
   serverScope.config = cfg;
-  cfg.requestDefaults = cfg.requestDefaults || {jar: false};
+  cfg.requestDefaults = cfg.requestDefaults || {jar: true};
 
   const httpAgent = (typeof cfg.request === 'function') ? cfg.request :
     request.defaults(cfg.requestDefaults);
@@ -282,12 +283,14 @@ module.exports = exports = nano = function dbScope(cfg) {
     log(req);
 
     if (opts.stream) {
+      // return the Request object for streaming
       return httpAgent(req, responseHandler(req, opts, null, null, callback));
     } else {
       if (typeof callback === 'function') {
+        // return nothing - feedback via the callback function
         httpAgent(req, responseHandler(req, opts, null, null, callback));
-        return Promise.resolve();
       } else {
+        // return a Promise
         return new Promise( function(resolve, reject) {
           httpAgent(req, responseHandler(req, opts, resolve, reject));
         });
@@ -472,12 +475,11 @@ module.exports = exports = nano = function dbScope(cfg) {
     // http://docs.couchdb.org/en/latest/api/document/common.html#delete--db-docid
     function destroyDoc(docName, rev, callback) {
       if(!docName) {
+        const msg = 'Invalid doc id';
         if(callback) {
-          const msg = 'Invalid doc id';
           callback(msg, null);
-          return new Promise(function(resolve, reject) {
-            reject(msg);
-          });
+        } else {
+          return Promise.reject(msg);
         }
       }
       else {

--- a/lib/nano.js
+++ b/lib/nano.js
@@ -284,9 +284,14 @@ module.exports = exports = nano = function dbScope(cfg) {
     if (opts.stream) {
       return httpAgent(req, responseHandler(req, opts, null, null, callback));
     } else {
-      return new Promise( function(resolve, reject) {
-        httpAgent(req, responseHandler(req, opts, resolve, reject, callback));
-      });
+      if (typeof callback === 'function') {
+        httpAgent(req, responseHandler(req, opts, null, null, callback));
+        return Promise.resolve();
+      } else {
+        return new Promise( function(resolve, reject) {
+          httpAgent(req, responseHandler(req, opts, resolve, reject));
+        });
+      }
     }
   }
 
@@ -628,14 +633,14 @@ module.exports = exports = nano = function dbScope(cfg) {
           body: body,
           stream: meta.stream
         }, callback);
-      } else if (qs && qs.queries) {
-        body = {queries: qs.queries};
-        delete qs.queries;
+      } else if (qs1 && qs1.queries) {
+        const body = {queries: qs1.queries};
+        delete qs1.queries;
         return relax({
           db: dbName,
           path: viewPath,
           method: 'POST',
-          qs: qs,
+          qs: qs1,
           body: body
         }, callback);
       } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nano",
-  "version": "6.4.4",
+  "version": "7.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "homepage": "http://github.com/apache/couchdb-nano",
   "repository": "http://github.com/apache/couchdb-nano",
-  "version": "6.4.4",
+  "version": "7.0.0",
   "author": "Apache CouchDB <dev@couchdb.apache.org> (http://couchdb.apache.org)",
   "keywords": [
     "couchdb",

--- a/tests/fixtures/document/head.json
+++ b/tests/fixtures/document/head.json
@@ -14,6 +14,10 @@
   , "method"   : "head"
   , "headers"  : { "statusCode" : 200 }
   }
+, { "path"     : "/document_head/foobaz"
+  , "method"   : "head"
+  , "headers"  : { "statusCode" : 200 }
+  }
 , { "method"   : "delete"
   , "path"     : "/document_head"
   , "response" : "{ \"ok\": true }"

--- a/tests/integration/attachment/destroy.js
+++ b/tests/integration/attachment/destroy.js
@@ -18,21 +18,13 @@ const it = harness.it;
 const db = harness.locals.db;
 
 it('should be able to insert a new plain text attachment', function(assert) {
-  const p = db.attachment.insert('new',
-  'att', 'Hello World!', 'text/plain', function(error, att) {
-    assert.equal(error, null, 'store the attachment');
-    assert.equal(att.ok, true, 'response ok');
-    assert.ok(att.rev, 'have a revision number');
-    db.attachment.destroy('new', 'att', {rev: att.rev},
-    function(error, response) {
-      assert.equal(error, null, 'delete the attachment');
-      assert.equal(response.ok, true, 'response ok');
-      assert.equal(response.id, 'new', '`id` should be `new`');
-    });
-  });
+  const p = db.attachment.insert('new', 'att', 'Hello World!', 'text/plain');
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(response) {
-    assert.ok(true, 'Promise is resolved');
+    assert.equal(att.ok, true, 'response ok');
+    assert.ok(att.rev, 'have a revision number');
+    return db.attachment.destroy('new', 'att', {rev: att.rev});
+  }).then(function(response) {
     assert.equal(response.ok, true, 'response ok');
     assert.equal(response.id, 'new', '`id` should be `new`');
     assert.end();
@@ -42,12 +34,11 @@ it('should be able to insert a new plain text attachment', function(assert) {
 });
 
 it('should fail destroying with a bad filename', function(assert) {
-  const p = db.attachment.destroy('new', false, true, function(error, response) {
-    assert.equal(response, undefined, 'no response should be given');
-  });
+  const p = db.attachment.destroy('new', false, true);
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function() {
     assert.ok(false, 'Promise is resolved');
+    assert.end();
   }).catch(function() {
     assert.ok(true, 'Promise is rejected');
     assert.end();

--- a/tests/integration/attachment/get.js
+++ b/tests/integration/attachment/get.js
@@ -18,45 +18,28 @@ const it = harness.it;
 const db = harness.locals.db;
 
 it('should be able to fetch an attachment', function(assert) {
-  db.attachment.insert('new_string', 'att', 'Hello', 'text/plain',
-  function(error, hello) {
-    assert.equal(error, null, 'should store `hello`');
+  let p = db.attachment.insert('new_string', 'att', 'Hello', 'text/plain');
+  assert.ok(helpers.isPromise(p), 'returns Promise');
+  p.then(function(hello) {
     assert.equal(hello.ok, true, 'response ok');
     assert.ok(hello.rev, 'should have a revision number');
-    const p = db.attachment.get('new_string', 'att',
-    function(error, helloWorld) {
-      assert.equal(error, null, 'should get `hello`');
-      assert.equal('Hello', helloWorld.toString(), 'string is reflexive');
-    });
-    assert.ok(helpers.isPromise(p), 'returns Promise');
-    p.then(function(s) {
-      assert.ok(true, 'Promise is resolved');
-      assert.equal('Hello', s.toString(), 'string is reflexive');
-      assert.end();
-    }).catch(function() {
-      assert.ok(false, 'Promise is rejected');
-    });
+    return db.attachment.get('new_string', 'att')
+  }).then(function(helloWorld) {
+    assert.equal('Hello', helloWorld.toString(), 'string is reflexive');
+    assert.end();
   });
 });
 
 it('should insert and fetch a binary file', function(assert) {
-  db.attachment.insert('new_binary', 'att', new Buffer('123'),
-  'text/plain', function(error, hello) {
-    assert.equal(error, null, 'should store `123`');
+  let p = db.attachment.insert('new_binary', 'att', new Buffer('123'), 'text/plain')
+  assert.ok(helpers.isPromise(p), 'returns Promise');
+  p.then(function(hello) {
     assert.equal(hello.ok, true, 'response ok');
     assert.ok(hello.rev, 'should have a revision number');
-    const p = db.attachment.get('new_binary', 'att',
-    function(error, binaryData) {
-      assert.equal(error, null, 'should get the binary data');
-      assert.equal('123', binaryData.toString(), 'binary data is reflexive');
-    });
-    assert.ok(helpers.isPromise(p), 'returns Promise');
-    p.then(function(binaryData) {
-      assert.ok(true, 'Promise is resolved');
-      assert.equal('123', binaryData.toString(), 'binary data is reflexive');
-      assert.end();
-    }).catch(function() {
-      assert.ok(false, 'Promise is rejected');
-    });
+    return  db.attachment.get('new_binary', 'att');
+  }).then(function(binaryData) {
+    assert.equal(error, null, 'should get the binary data');
+    assert.equal('123', binaryData.toString(), 'binary data is reflexive');
+    assert.end();
   });
 });

--- a/tests/integration/attachment/insert.js
+++ b/tests/integration/attachment/insert.js
@@ -18,19 +18,11 @@ const it = harness.it;
 const db = harness.locals.db;
 
 it('should be able to insert a simple attachment', function(assert) {
-  const p = db.attachment.insert('new', 'att', 'Hello World!', 'text/plain',
-  function(error, att) {
-    assert.equal(error, null, 'should store the attachment');
-    assert.equal(att.ok, true, 'response ok');
-    assert.ok(att.rev, 'should have a revision');
-  });
+  const p = db.attachment.insert('new', 'att', 'Hello World!', 'text/plain')
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(att) {
-    assert.ok(true, 'Promise is resolved');
     assert.equal(att.ok, true, 'response ok');
     assert.ok(att.rev, 'should have a revision');
     assert.end();
-  }).catch(function() {
-    assert.ok(false, 'Promise is rejected');
   });
 });

--- a/tests/integration/attachment/pipe.js
+++ b/tests/integration/attachment/pipe.js
@@ -31,11 +31,10 @@ it('should be able to pipe to a writeStream', function(assert) {
     assert.end();
   });
 
-  db.attachment.insert('new', 'att', buffer, 'image/bmp',
-  function(error, bmp) {
-    assert.equal(error, null, 'Should store the pixel');
-    db.attachment.getAsStream('new', 'att', {rev: bmp.rev}).pipe(ws);
-  });
+  db.attachment.insert('new', 'att', buffer, 'image/bmp')
+    .then(function(bmp) {
+      db.attachment.getAsStream('new', 'att', {rev: bmp.rev}).pipe(ws);
+    });
 });
 
 it('should be able to pipe to a writeStream', function(assert) {

--- a/tests/integration/attachment/update.js
+++ b/tests/integration/attachment/update.js
@@ -22,36 +22,25 @@ let rev;
 
 it('should be able to insert and update attachments', function(assert) {
   const buffer = new Buffer(pixel, 'base64');
-  db.attachment.insert('new', 'att', 'Hello', 'text/plain',
-  function(error, hello) {
-    assert.equal(error, null, 'should store hello');
+  const p = db.attachment.insert('new', 'att', 'Hello', 'text/plain');
+  assert.ok(helpers.isPromise(p), 'returns Promise');
+  p.then(function(hello) {
     assert.equal(hello.ok, true, 'response ok');
     assert.ok(hello.rev, 'should have a revision');
-    const p = db.attachment.insert('new', 'att', buffer, 'image/bmp',
-    {rev: hello.rev}, function(error, bmp) {
-      assert.equal(error, null, 'should store the pixel');
-      assert.ok(bmp.rev, 'should store a revision');
-      rev = bmp.rev;
-    });
-    assert.ok(helpers.isPromise(p), 'returns Promise');
-    p.then(function(s) {
-      assert.ok(true, 'Promise is resolved');
-      assert.ok(s.rev, 'should store a revision');
-      assert.end();
-    }).catch(function() {
-      assert.ok(false, 'Promise is rejected');
-    });
+    return db.attachment.insert('new', 'att', buffer, 'image/bmp',{rev: hello.rev});
+  }).then(function(bmp) {
+    assert.ok(bmp.rev, 'should store a revision');
+    rev = bmp.rev;
+    assert.end();
   });
 });
 
 it('should be able to fetch the updated pixel', function(assert) {
-  db.get('new', function(error, newDoc) {
-    assert.equal(error, null, 'should get new');
+  db.get('new').then(function(newDoc) {
     newDoc.works = true;
-    db.insert(newDoc, 'new', function(error, response) {
-      assert.equal(error, null, 'should update doc');
-      assert.equal(response.ok, true, 'response ok');
-      assert.end();
-    });
+    return db.insert(newDoc, 'new');
+  }).then(function(response) {
+    assert.equal(response.ok, true, 'response ok');
+    assert.end();
   });
 });

--- a/tests/integration/database/changes.js
+++ b/tests/integration/database/changes.js
@@ -20,15 +20,11 @@ const it = harness.it;
 it('should be able to insert three documents', helpers.insertThree);
 
 it('should be able to receive changes since seq:0', function(assert) {
-  const p = db.changes({since:0}, function(error, response) {
-    assert.equal(error, null, 'gets response from changes');
-    assert.equal(response.results.length, 3, 'gets three results');
-  });
+  const p = db.changes({since:0});
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(response) {
-    assert.ok(true, 'Promise is resolved');
     assert.equal(response.results.length, 3, 'gets three results');
-    assert.end();
+    assert.end()
   }).catch(function() {
     assert.ok(false, 'Promise is rejected');
   });

--- a/tests/integration/database/compact.js
+++ b/tests/integration/database/compact.js
@@ -18,32 +18,27 @@ const it = harness.it;
 const db = harness.locals.db;
 
 it('should store and delete `goofy`', function(assert) {
-  db.insert({'foo': 'baz'}, 'goofy', function(error, foo) {
-    assert.equal(error, null, 'should have stored foo');
+  let p = db.insert({'foo': 'baz'}, 'goofy');
+  assert.ok(helpers.isPromise(p), 'returns Promise');
+  p.then(function(foo) {
     assert.equal(foo.ok, true, 'response should be ok');
-    db.destroy('goofy', foo.rev, function(error, response) {
-      assert.equal(error, null, 'should have deleted foo');
-      assert.equal(response.ok, true, 'response ok');
-      assert.end();
-    });
+    return db.destroy('goofy', foo.rev);
+  }).then(function(response) {
+    assert.equal(response.ok, true, 'response ok');
+    assert.end();
+  }).catch(function() {
+    assert.ok(false, 'Promise is rejected');
   });
 });
 
 it('should have run the compaction', function(assert) {
-  const p = db.compact(function(error) {
-    assert.equal(error, null, 'compact should respond');
-    db.info(function(error, info) {
-      assert.equal(error, null, 'info should respond');
-      assert.equal(info['doc_count'], 0, 'document count is not 3');
-      assert.equal(info['doc_del_count'], 1, 'document should be deleted');
-    });
-  });
+  const p = db.compact();
   assert.ok(helpers.isPromise(p), 'returns Promise');
-  p.then(function(info) {
-    assert.ok(true, 'Promise is resolved');
+  p.then(function() {
+    return  db.info();
+  }).then(function(info) {
     assert.equal(info['doc_count'], 0, 'document count is not 3');
     assert.equal(info['doc_del_count'], 1, 'document should be deleted');
-    assert.end();
   }).catch(function() {
     assert.ok(false, 'Promise is rejected');
   });

--- a/tests/integration/database/create-and-destroy.js
+++ b/tests/integration/database/create-and-destroy.js
@@ -19,9 +19,10 @@ const it = harness.it;
 const nano = harness.locals.nano;
 
 it('should be able to create `az09_$()+-/` database', function(assert) {
-  nano.db.create('az09_$()+-/', function(err) {
-    assert.equal(err, null, 'should create database');
+  nano.db.create('az09_$()+-/').then(function(err) {
     assert.end();
+  }).catch(function() {
+    assert.ok(false, 'Promise is rejected');
   });
 });
 

--- a/tests/integration/database/get.js
+++ b/tests/integration/database/get.js
@@ -18,17 +18,12 @@ const it = harness.it;
 const nano = harness.locals.nano;
 
 it('should be able to fetch the database', function(assert) {
-  const p = nano.db.get('database_get', function(error, response) {
-    assert.equal(error, null, 'should get the db');
-    assert.equal(response['doc_count'], 0, 'should be empty');
-    assert.equal(response['db_name'], 'database_get', 'name');
-  });
+
+  const p = nano.db.get('database_get');
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(response) {
-    assert.ok(true, 'Promise is resolved');
     assert.equal(response['doc_count'], 0, 'should be empty');
     assert.equal(response['db_name'], 'database_get', 'name');
-    assert.end();
   }).catch(function() {
     assert.ok(false, 'Promise is rejected');
   });

--- a/tests/integration/database/list.js
+++ b/tests/integration/database/list.js
@@ -18,27 +18,24 @@ const it = harness.it;
 const nano = harness.locals.nano;
 
 it('should ensure _replicator and _users are created', function(assert) {
-  nano.db.create('_replicator', function() {
-    nano.db.destroy('_users', function() {
-      nano.db.create('_users', function() {
-        assert.end();
-      });
-    });
+  nano.db.create('_replicator').then(function() {
+    return nano.db.destroy('_users');
+  }).then(function() {
+    return nano.db.create('_users'); 
+  }).then(function() {
+    assert.end();
   });
 });
 
 it('should list the correct databases', function(assert) {
-  const p = nano.db.list(function(error, list) {
-    assert.equal(error, null, 'should list databases');
+  const p = nano.db.list()
+  assert.ok(helpers.isPromise(p), 'returns Promise');
+  p.then(function(list) {
     const filtered = list.filter(function(e) {
       return e === 'database_list' || e === '_replicator' || e === '_users';
     });
     assert.equal(filtered.length, 3, 'should have exactly 3 dbs');
-  });
-  assert.ok(helpers.isPromise(p), 'returns Promise');
-  p.then(function() {
-    assert.ok(true, 'Promise is resolved');
-    assert.end();
+    assert.end()
   }).catch(function() {
     assert.ok(false, 'Promise is rejected');
   });

--- a/tests/integration/database/replicate.js
+++ b/tests/integration/database/replicate.js
@@ -34,19 +34,12 @@ it('creates a bunch of database replicas', function(assert) {
 
 it('should be able to replicate three docs', function(assert) {
   replica = nano.use('database_replica');
-
-  const p = db.replicate('database_replica', function(error) {
-    assert.equal(error, null, 'replication should work');
-    replica.list(function(error, list) {
-      assert.equal(error, null, 'should be able to invoke list');
-      assert.equal(list['total_rows'], 3, 'and have three documents');
-    });
-  });
+  const p = db.replicate('database_replica')
   assert.ok(helpers.isPromise(p), 'returns Promise');
-  p.then(function(list) {
-    assert.ok(true, 'Promise is resolved');
+  p.then(function() {
+    return replica.list();
+  }).then(function(list) {
     assert.equal(list['total_rows'], 3, 'and have three documents');
-    assert.end();
   }).catch(function() {
     assert.ok(false, 'Promise is rejected');
   });
@@ -54,21 +47,21 @@ it('should be able to replicate three docs', function(assert) {
 
 it('should be able to replicate to a `nano` object', function(assert) {
   replica2 = nano.use('database_replica2');
-
-  nano.db.replicate(db, replica2, function(error) {
-    assert.equal(error, null, 'should replicate');
-    replica2.list(function(error, list) {
-      assert.equal(error, null, 'should list');
-      assert.equal(list['total_rows'], 3, 'and have three documents');
-      assert.end();
-    });
+  let p = nano.db.replicate(db, replica2);
+  assert.ok(helpers.isPromise(p), 'returns Promise');
+  p.then(function() {
+    return replica2.list();
+  }).then(function(list) {
+    assert.equal(list['total_rows'], 3, 'and have three documents');
+    assert.end();
+  }).catch(function() {
+    assert.ok(false, 'Promise is rejected');
   });
+  
 });
 
 it('should be able to replicate with params', function(assert) {
-  const p = db.replicate('database_replica', {}, function(error) {
-    assert.equal(error, null, 'replication should work');
-  });
+  const p = db.replicate('database_replica', {});
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function() {
     assert.ok(true, 'Promise is resolved');

--- a/tests/integration/design/list.js
+++ b/tests/integration/design/list.js
@@ -25,9 +25,6 @@ it('should get the people by running the ddoc', function(assert) {
       'Derek',
       'San Francisco'
     ]
-  }, function(error, list) {
-    assert.equal(error, null, 'should response');
-    assert.equal(list, 'Hello', 'and list should be `hello`');
   });
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(list) {

--- a/tests/integration/design/multiple.js
+++ b/tests/integration/design/multiple.js
@@ -24,10 +24,7 @@ it('should be able to insert docs and design doc', function(assert) {
         map: 'function(doc) { emit(doc._id, doc); }'
       }
     }
-  }, '_design/alice', function(error, response) {
-    assert.equal(error, null, 'should create views');
-    assert.equal(response.ok, true, 'response ok');
-  });
+  }, '_design/alice');
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(response) {
     assert.ok(true, 'Promise is resolved');
@@ -44,11 +41,6 @@ it('get multiple docs with a composed key', function(assert) {
   const p = db.view('alice', 'by_id', {
     keys: ['foobar', 'barfoo'],
     'include_docs': true
-  }, function(err, view) {
-    assert.equal(err, null, 'should response');
-    assert.equal(view.rows.length, 2, 'has more or less than two rows');
-    assert.equal(view.rows[0].id, 'foobar', 'foo is not the first id');
-    assert.equal(view.rows[1].id, 'barfoo', 'bar is not the second id');
   });
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(view) {

--- a/tests/integration/design/show.js
+++ b/tests/integration/design/show.js
@@ -73,13 +73,7 @@ it('should insert a show ddoc', function(assert) {
 });
 
 it('should show the amazing clemens in json', function(assert) {
-  const p = db.show('people', 'singleDoc', 'p_clemens', function(error, doc, rh) {
-    assert.equal(error, null, 'its alive');
-    assert.equal(rh['content-type'], 'application/json');
-    assert.equal(doc.name, 'Clemens');
-    assert.equal(doc.city, 'Dresden');
-    assert.equal(doc.format, 'json');
-  });
+  const p = db.show('people', 'singleDoc', 'p_clemens');
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(doc) {
     assert.ok(true, 'Promise is resolved');

--- a/tests/integration/document/bulk.js
+++ b/tests/integration/document/bulk.js
@@ -23,12 +23,6 @@ it('should be able to bulk insert two docs', function(assert) {
       {'key':'baz', 'name':'bazzel'},
       {'key':'bar', 'name':'barry'}
     ]
-  },
-  function(error, response) {
-    assert.equal(error, null, 'no error');
-    assert.equal(response.length, 2, 'has two docs');
-    assert.ok(response[0].id, 'first got id');
-    assert.ok(response[1].id, 'other also got id');
   });
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(response) {

--- a/tests/integration/document/copy.js
+++ b/tests/integration/document/copy.js
@@ -32,12 +32,7 @@ it('must insert two docs before the tests start', function(assert) {
 });
 
 it('should be able to copy and overwrite a document', function(assert) {
-  const p = db.copy('foo_src', 'foo_dest', {overwrite: true},
-  function(error, response, headers) {
-    assert.equal(error, null,
-      'should have copied and overwritten foo_src to foo_dest');
-    assert.equal(headers['statusCode'], 201, 'status code should be 201');
-  });
+  const p = db.copy('foo_src', 'foo_dest', {overwrite: true});
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function() {
     assert.ok(true, 'Promise is resolved');
@@ -49,9 +44,7 @@ it('should be able to copy and overwrite a document', function(assert) {
 
 it('copy without overwrite should return conflict for exists docs',
 function(assert) {
-  const p = db.copy('foo_src', 'foo_dest', function(error) {
-    assert.equal(error.error, 'conflict', 'should be a conflict');
-  });
+  const p = db.copy('foo_src', 'foo_dest');
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function() {
     assert.ok(false, 'Promise is resolved');
@@ -62,10 +55,7 @@ function(assert) {
 });
 
 it('copy to a new destination should work', function(assert) {
-  const p = db.copy('foo_src', 'baz_dest', function(error, response, headers) {
-    assert.equal(error, null, 'copies into new document');
-    assert.equal(headers['statusCode'], 201, 'Status code should be 201');
-  });
+  const p = db.copy('foo_src', 'baz_dest');
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function() {
     assert.ok(true, 'Promise is resolved');

--- a/tests/integration/document/create_index.js
+++ b/tests/integration/document/create_index.js
@@ -23,10 +23,6 @@ it ('Should create one simple index', function(assert) {
   const p = db.createIndex({
     name: 'fooindex',
     index: { fields: ['foo'] }
-  }, function(error, foo) {
-    assert.equal(error, null, 'should have indexed fields');
-    assert.equal(foo.result, 'created', 'index should be created');
-    assert.equal(foo.name, 'fooindex', 'index should have correct name');
   });
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(foo) {

--- a/tests/integration/document/destroy.js
+++ b/tests/integration/document/destroy.js
@@ -30,10 +30,7 @@ it('should insert a document', function(assert) {
 });
 
 it('should not delete a db', function(assert) {
-  const p = db.destroy(undefined, undefined, function(error, response) {
-    assert.equal(error, 'Invalid doc id', 'validated delete parameters');
-    assert.equal(response, null, 'ok!');
-  });
+  const p = db.destroy(undefined, undefined);
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function() {
     assert.ok(false, 'Promise is resolved');
@@ -44,10 +41,7 @@ it('should not delete a db', function(assert) {
 });
 
 it('should delete a document', function(assert) {
-  const p = db.destroy('foobaz', rev, function(error, response) {
-    assert.equal(error, null, 'deleted foo');
-    assert.equal(response.ok, true, 'ok!');
-  });
+  const p = db.destroy('foobaz', rev);
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(response) {
     assert.ok(true, 'Promise is resolved');

--- a/tests/integration/document/fetch.js
+++ b/tests/integration/document/fetch.js
@@ -20,11 +20,7 @@ const it = harness.it;
 it('should insert a bunch of items', helpers.insertThree);
 
 it('should be able to fetch with one key', function(assert) {
-  const p = db.fetch({keys:['foobar']}, function(error, docs) {
-    assert.equal(error, null, 'should work');
-    assert.equal(docs.rows.length, 1, 'and get one row');
-    assert.equal(docs['total_rows'], 3, 'out of 3');
-  });
+  const p = db.fetch({keys:['foobar']});
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(docs) {
     assert.ok(true, 'Promise is resolved');
@@ -37,11 +33,7 @@ it('should be able to fetch with one key', function(assert) {
 });
 
 it('should be able to fetch with multiple keys', function(assert) {
-  const p = db.fetch({keys:['foobar', 'barfoo']}, function(error, docs) {
-    assert.equal(error, null, 'no errors');
-    assert.equal(docs.rows.length, 2, 'two rows');
-    assert.equal(docs['total_rows'], 3, 'out of 3');
-  });
+  const p = db.fetch({keys:['foobar', 'barfoo']});
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(docs) {
     assert.ok(true, 'Promise is resolved');
@@ -54,11 +46,7 @@ it('should be able to fetch with multiple keys', function(assert) {
 });
 
 it('should be able to fetch with params', function(assert) {
-  const p = db.fetch({keys:['foobar']}, {not: 'important'}, function(error, docs) {
-    assert.equal(error, null, 'should work');
-    assert.equal(docs.rows.length, 1, 'and get one row');
-    assert.equal(docs['total_rows'], 3, 'out of 3');
-  });
+  const p = db.fetch({keys:['foobar']}, {not: 'important'});
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(docs) {
     assert.ok(true, 'Promise is resolved');

--- a/tests/integration/document/fetch_revs.js
+++ b/tests/integration/document/fetch_revs.js
@@ -20,12 +20,7 @@ const it = harness.it;
 it('should insert a bunch of items', helpers.insertThree);
 
 it('should be able to fetch with one key', function(assert) {
-  const p = db.fetchRevs({keys:['foobar']}, function(error, docs) {
-    assert.equal(error, null, 'should work');
-    assert.equal(docs.rows.length, 1, 'and get one row');
-    assert.equal(docs['total_rows'], 3, 'out of 3');
-    assert.equal(docs.rows[0].doc, undefined, 'rev should not return key');
-  });
+  const p = db.fetchRevs({keys:['foobar']});
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(docs) {
     assert.ok(true, 'Promise is resolved');
@@ -39,13 +34,7 @@ it('should be able to fetch with one key', function(assert) {
 });
 
 it('should be able to fetch with multiple keys', function(assert) {
-  const p = db.fetchRevs({keys:['foobar', 'barfoo']}, function(error, docs) {
-    assert.equal(error, null, 'it works');
-    assert.equal(docs.rows.length, 2, 'two rows');
-    assert.equal(docs['total_rows'], 3, 'out of 3');
-    assert.equal(docs.rows[0].doc, undefined, 'no doc in 1');
-    assert.equal(docs.rows[1].doc, undefined, 'no doc in 2');
-  });
+  const p = db.fetchRevs({keys:['foobar', 'barfoo']});
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(docs) {
     assert.ok(true, 'Promise is resolved');
@@ -60,12 +49,7 @@ it('should be able to fetch with multiple keys', function(assert) {
 });
 
 it('should be able to fetch with params', function(assert) {
-  const p = db.fetchRevs({keys:['foobar']}, {still: 'no'}, function(error, docs) {
-    assert.equal(error, null, 'should work');
-    assert.equal(docs.rows.length, 1, 'and get one row');
-    assert.equal(docs['total_rows'], 3, 'out of 3');
-    assert.equal(docs.rows[0].doc, undefined, 'rev should not return key');
-  });
+  const p = db.fetchRevs({keys:['foobar']}, {still: 'no'});
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(docs) {
     assert.ok(true, 'Promise is resolved');

--- a/tests/integration/document/find.js
+++ b/tests/integration/document/find.js
@@ -20,10 +20,7 @@ const it = harness.it;
 it('should insert a bunch of items', helpers.insertThree);
 
 it('should be to do a mango query', function(assert) {
-  const p = db.find({ selector: { foo: 'baz'}}, function(error, response) {
-    assert.equal(error, null, 'should work');
-    assert.equal(response.docs.length, 1, 'and get one row');
-  });
+  const p = db.find({ selector: { foo: 'baz'}});
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(response) {
     assert.ok(true, 'Promise is resolved');

--- a/tests/integration/document/get.js
+++ b/tests/integration/document/get.js
@@ -20,12 +20,7 @@ const it = harness.it;
 it('should insert a one item', helpers.insertOne);
 
 it('should get the document', function(assert) {
-  const p = db.get('foobaz', {'revs_info': true}, function(error, foobaz) {
-    assert.equal(error, null, 'should get foobaz');
-    assert.ok(foobaz['_revs_info'], 'got revs info');
-    assert.equal(foobaz._id, 'foobaz', 'id is food');
-    assert.equal(foobaz.foo, 'baz', 'baz is in foo');
-  });
+  const p = db.get('foobaz', {'revs_info': true});
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(foobaz) {
     assert.ok(true, 'Promise is resolved');

--- a/tests/integration/document/head.js
+++ b/tests/integration/document/head.js
@@ -19,11 +19,8 @@ const it = harness.it;
 
 it('should insert a one item', helpers.insertOne);
 
-it('should get a status code when you do head', function(assert) {
-  const p = db.head('foobaz', function(error, body, headers) {
-    assert.equal(error, null, 'should get the head of foobaz');
-    assert.equal(headers['statusCode'], 200, 'and is ok');
-  });
+it('should get a status code when you do head - promises', function(assert) {
+  const p = db.head('foobaz');
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(docs) {
     assert.ok(true, 'Promise is resolved');
@@ -31,5 +28,12 @@ it('should get a status code when you do head', function(assert) {
     assert.end();
   }).catch(function() {
     assert.ok(false, 'Promise is rejected');
+  });
+});
+
+it('should get a status code when you do head - callbacks', function(assert) {
+  db.head('foobaz', function(error, body, headers) {
+    assert.equal(error, null, 'should get the head of foobaz');
+    assert.equal(headers['statusCode'], 200, 'and is ok');
   });
 });

--- a/tests/integration/document/insert.js
+++ b/tests/integration/document/insert.js
@@ -20,12 +20,7 @@ const it = harness.it;
 let rev;
 
 it('should insert one simple document', function(assert) {
-  const p = db.insert({'foo': 'baz'}, 'foobaz', function(error, foo) {
-    rev = foo.rev;
-    assert.equal(error, null, 'should have stored foo');
-    assert.equal(foo.ok, true, 'response should be ok');
-    assert.ok(foo.rev, 'response should have rev');
-  });
+  const p = db.insert({'foo': 'baz'}, 'foobaz');
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(foo) {
     assert.ok(true, 'Promise is resolved');
@@ -38,11 +33,7 @@ it('should insert one simple document', function(assert) {
 });
 
 it('should fail to insert again since it already exists', function(assert) {
-  const p = db.insert({}, 'foobaz', function(error) {
-    assert.equal(error['statusCode'], 409, 'should be conflict');
-    assert.equal(error.scope, 'couch', 'scope is couch');
-    assert.equal(error.error, 'conflict', 'type is conflict');
-  });
+  const p = db.insert({}, 'foobaz');
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function() {
     assert.ok(false, 'Promise is resolved');
@@ -61,10 +52,6 @@ it('should be able to use custom params in insert', function(assert) {
   }, {
     docName: 'foobaz',
     'new_edits': false
-  }, function(error, foo) {
-    assert.equal(error, null, 'should have stored foo');
-    assert.equal(foo.ok, true, 'response should be ok');
-    assert.ok(foo.rev, 'response should have rev');
   });
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(foo) {
@@ -78,18 +65,18 @@ it('should be able to use custom params in insert', function(assert) {
 });
 
 it('should be able to insert functions in docs', function(assert) {
-  const p = db.insert({
+  db.insert({
     fn: function() { return true; },
     fn2: 'function () { return true; }'
-  }, function(error, fns) {
-    assert.equal(error, null, 'should have stored foo');
+  }).then(function(fns) {
+
     assert.equal(fns.ok, true, 'response should be ok');
     assert.ok(fns.rev, 'response should have rev');
-    db.get(fns.id, function(error, fns) {
-      assert.equal(fns.fn, fns.fn2, 'fn matches fn2');
-      assert.equal(error, null, 'should get foo');
-      assert.end();
-    });
+    return db.get(fns.id);
+  }).then(function(fns) {
+    assert.equal(fns.fn, fns.fn2, 'fn matches fn2');
+    assert.end();
+  }).catch(function() {
+    assert.ok(false, 'Promise is rejected');
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise');
 });

--- a/tests/integration/document/list.js
+++ b/tests/integration/document/list.js
@@ -21,11 +21,7 @@ const it = harness.it;
 it('should insert a bunch of items', helpers.insertThree);
 
 it('should list the three documents', function(assert) {
-  const p = db.list(function(error, docs) {
-    assert.equal(error, null, 'should get list');
-    assert.equal(docs['total_rows'], 3, 'with total three rows');
-    assert.ok(docs.rows, 'and the rows themselves');
-  });
+  const p = db.list();
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(docs) {
     assert.ok(true, 'Promise is resolved');
@@ -53,13 +49,7 @@ it('should be able to list using the `relax` function', function(assert) {
 });
 
 it('should be able to list with a start_key', function(assert) {
-  const p = db.list({start_key: 'c'}, function(error, docs) {
-    assert.equal(error, null, 'should work');
-    assert.ok(docs.rows, 'get the rows');
-    assert.equal(docs.rows.length, 2, 'starts in row two');
-    assert.equal(docs['total_rows'], 3, 'out of three rows');
-    assert.equal(docs.offset, 1, 'offset is 1');
-  });
+  const p = db.list({start_key: 'c'});
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(docs) {
     assert.ok(true, 'Promise is resolved');
@@ -74,13 +64,7 @@ it('should be able to list with a start_key', function(assert) {
 });
 
 it('should be able to list with a startkey', function(assert) {
-  const p = db.list({startkey: 'c'}, function(error, docs) {
-    assert.equal(error, null, 'should work');
-    assert.ok(docs.rows, 'get the rows');
-    assert.equal(docs.rows.length, 2, 'starts in row two');
-    assert.equal(docs['total_rows'], 3, 'out of three rows');
-    assert.equal(docs.offset, 1, 'offset is 1');
-  });
+  const p = db.list({startkey: 'c'});
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(docs) {
     assert.ok(true, 'Promise is resolved');
@@ -95,13 +79,7 @@ it('should be able to list with a startkey', function(assert) {
 });
 
 it('should be able to list with a endkey', function(assert) {
-  const p = db.list({endkey: 's'}, function(error, docs) {
-    assert.equal(error, null, 'should work');
-    assert.ok(docs.rows, 'get the rows');
-    assert.equal(docs.rows.length, 2, 'starts in row two');
-    assert.equal(docs['total_rows'], 3, 'out of three rows');
-    assert.equal(docs.offset, 1, 'offset is 1');
-  });
+  const p = db.list({endkey: 's'});
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(docs) {
     assert.ok(true, 'Promise is resolved');
@@ -116,13 +94,7 @@ it('should be able to list with a endkey', function(assert) {
 });
 
 it('should be able to list with a end_key', function(assert) {
-  const p = db.list({end_key: 's'}, function(error, docs) {
-    assert.equal(error, null, 'should work');
-    assert.ok(docs.rows, 'get the rows');
-    assert.equal(docs.rows.length, 2, 'starts in row two');
-    assert.equal(docs['total_rows'], 3, 'out of three rows');
-    assert.equal(docs.offset, 1, 'offset is 1');
-  });
+  const p = db.list({end_key: 's'});
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(docs) {
     assert.ok(true, 'Promise is resolved');

--- a/tests/integration/document/update.js
+++ b/tests/integration/document/update.js
@@ -20,12 +20,7 @@ const it = harness.it;
 let rev;
 
 it('should insert one doc', function(assert) {
-  const p = db.insert({'foo': 'baz'}, 'foobar', function(error, foo) {
-    assert.equal(error, null, 'stored foo');
-    assert.equal(foo.ok, true, 'response ok');
-    assert.ok(foo.rev, 'withs rev');
-    rev = foo.rev;
-  });
+  const p = db.insert({'foo': 'baz'}, 'foobar');
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(foo) {
     assert.ok(true, 'Promise is resolved');
@@ -38,10 +33,7 @@ it('should insert one doc', function(assert) {
 });
 
 it('should update the document', function(assert) {
-  const p = db.insert({foo: 'bar', '_rev': rev}, 'foobar', function(error, response) {
-    assert.equal(error, null, 'should have deleted foo');
-    assert.equal(response.ok, true, 'response should be ok');
-  });
+  const p = db.insert({foo: 'bar', '_rev': rev}, 'foobar');
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(response) {
     assert.ok(true, 'Promise is resolved');

--- a/tests/integration/multipart/get.js
+++ b/tests/integration/multipart/get.js
@@ -25,14 +25,7 @@ it('should be able to insert a doc with att', function(assert) {
     data: 'Hello World!',
     'content_type': 'text/plain'
   };
-
-  const p = db.multipart.insert({'foo': 'baz'}, [att], 'foobaz', function(error, foo) {
-    assert.equal(error, null, 'should have stored foobaz');
-    assert.equal(foo.ok, true, 'response should be ok');
-    assert.equal(foo.id, 'foobaz', 'id is foobaz');
-    assert.ok(foo.rev, 'has rev');
-    rev = foo.rev;
-  });
+  const p = db.multipart.insert({'foo': 'baz'}, [att], 'foobaz');
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(foo) {
     assert.ok(true, 'Promise is resolved');
@@ -46,20 +39,12 @@ it('should be able to insert a doc with att', function(assert) {
 });
 
 it('should be able to get the document with the attachment', function(assert) {
-  const p = db.multipart.get('foobaz', function(error, foobaz, headers) {
+  db.multipart.get('foobaz', function(error, foobaz, headers) {
     assert.equal(error, null, 'should get foobaz');
     if (helpers.unmocked) {
       assert.ok(headers['content-type'], 'should have content type');
       assert.equal(headers['content-type'].split(';')[0], 'multipart/related');
     }
     assert.equal(typeof foobaz, 'object', 'foobaz should be a buffer');
-  });
-  assert.ok(helpers.isPromise(p), 'returns Promise');
-  p.then(function(foobaz) {
-    assert.ok(true, 'Promise is resolved');
-    assert.equal(typeof foobaz, 'object', 'foobaz should be a buffer');
-    assert.end();
-  }).catch(function() {
-    assert.ok(false, 'Promise is rejected');
   });
 });

--- a/tests/integration/multipart/insert.js
+++ b/tests/integration/multipart/insert.js
@@ -23,11 +23,7 @@ it('should handle crazy encodings', function(assert) {
     data: 'काचं शक्नोम्यत्तुम् । नोपहिनस्ति माम् ॥',
     'content_type': 'text/plain'
   };
-  const p = db.multipart.insert({'foo': 'bar'}, [att], 'foobar', function(error, foo) {
-    assert.equal(error, null, 'should have stored foo and attachment');
-    assert.equal(foo.ok, true, 'response should be ok');
-    assert.ok(foo.rev, 'response should have rev');
-  });
+  const p = db.multipart.insert({'foo': 'bar'}, [att], 'foobar');
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(foo) {
     assert.ok(true, 'Promise is resolved');
@@ -46,7 +42,7 @@ it('should test with presence of attachment', function(assert) {
     'content_type': 'text/plain'
   };
 
-  const p = db.attachment.insert('mydoc', 'one', 'Hello World!', 'text/plain',
+  db.attachment.insert('mydoc', 'one', 'Hello World!', 'text/plain',
   function(err) {
     assert.equal(err, null, 'should have stored the thingy');
     db.get('mydoc', function(_, doc) {
@@ -60,7 +56,6 @@ it('should test with presence of attachment', function(assert) {
       });
     });
   });
-  assert.ok(helpers.isPromise(p), 'returns Promise');
 });
 
 it('should work with attachment as a buffer', function(assert) {
@@ -69,11 +64,7 @@ it('should work with attachment as a buffer', function(assert) {
     data: new Buffer('foo'),
     'content_type': 'text/plain'
   };
-  const p = db.multipart.insert({'foo': 'bar'}, [att], 'otherdoc', function(error, foo) {
-    assert.equal(error, null, 'Should have stored foo and attachment');
-    assert.equal(foo.ok, true, 'Response should be ok');
-    assert.ok(foo.rev, 'Response should have rev');
-  });
+  const p = db.multipart.insert({'foo': 'bar'}, [att], 'otherdoc');
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(foo) {
     assert.ok(true, 'Promise is resolved');

--- a/tests/integration/shared/config.js
+++ b/tests/integration/shared/config.js
@@ -20,21 +20,11 @@ const Nano = helpers.Nano;
 const it = harness.it;
 
 it('should serve the root when no path is specified', function(assert) {
-  const p = nano.dinosaur('', function(err, response) {
-    assert.equal(err, null, 'failed to get root');
+  const p = nano.dinosaur('').then(function(response) {
     assert.ok(response.version, 'version is defined');
-    nano.relax(function(err, response) {
-      assert.equal(err, null, 'relax');
-      assert.ok(response.version, 'had version');
-    });
-  });
-  assert.ok(helpers.isPromise(p), 'returns Promise');
-  p.then(function(response) {
-    assert.ok(true, 'Promise is resolved');
-    assert.ok(response.version, 'version is defined');
-    assert.end();
-  }).catch(function() {
-    assert.ok(false, 'Promise is rejected');
+    return nano.relax();
+  }).then(function(response) {
+    assert.ok(response.version, 'had version');
   });
 });
 

--- a/tests/integration/shared/error.js
+++ b/tests/integration/shared/error.js
@@ -43,11 +43,7 @@ it('should be able to stream the simplest request', function(assert) {
 });
 
 it('should error when destroying a db that does not exist', function(assert) {
-  const p = nano.db.destroy('say_wat_wat', function(error) {
-    assert.ok(error, 'an error');
-    assert.ok(error.message, 'a note');
-    assert.equal(error.message, 'Database does not exist.', 'is missing');
-  });
+  const p = nano.db.destroy('say_wat_wat');
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function() {
     assert.ok(false, 'Promise is resolved');

--- a/tests/integration/util/uuid.js
+++ b/tests/integration/util/uuid.js
@@ -18,12 +18,7 @@ const nano = helpers.nano;
 const it = harness.it;
 
 it('should generate three uuids', function(assert) {
-  const p = nano.uuids(3, function(error, data) {
-    assert.equal(error, null, 'should generate uuids');
-    assert.ok(data, 'got response');
-    assert.ok(data.uuids, 'got uuids');
-    assert.equal(data.uuids.length, 3, 'got 3');
-  });
+  const p = nano.uuids(3);
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(data) {
     assert.ok(true, 'Promise is resolved');
@@ -37,12 +32,7 @@ it('should generate three uuids', function(assert) {
 });
 
 it('should generate one uuid', function(assert) {
-  const p = nano.uuids(function(error, data) {
-    assert.equal(error, null, 'should generate uuids');
-    assert.ok(data, 'got response');
-    assert.ok(data.uuids, 'got uuid');
-    assert.equal(data.uuids.length, 1, 'got 1');
-  });
+  const p = nano.uuids();
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(data) {
     assert.ok(true, 'Promise is resolved');

--- a/tests/intercept/design/search.js
+++ b/tests/intercept/design/search.js
@@ -26,11 +26,7 @@ const n = nano({url: 'http://localhost:5984', request: fakeRequest});
 const db = n.db.use('fake');
 
 it('should allow custom request object to be supplied', function(assert) {
-  const p = db.info(function(err, data) {
-      assert.equal(err, null);
-      assert.equal(data.method, 'GET');
-      assert.equal(typeof data.headers, 'object');
-  });
+  const p = db.info();
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(data) {
     assert.ok(true, 'Promise is resolved');
@@ -43,13 +39,7 @@ it('should allow custom request object to be supplied', function(assert) {
 });
 
 it('should encode array counts parameter', function(assert) {
-  const p = db.search('fake', 'fake', { counts: ['brand','colour'] }, function(err, data) {
-      assert.equal(err, null);
-      assert.equal(data.method, 'GET');
-      assert.equal(typeof data.headers, 'object');
-      assert.equal(typeof data.qs, 'object');
-      assert.equal(data.qs.counts, JSON.stringify(['brand','colour']));
-  });
+  const p = db.search('fake', 'fake', { counts: ['brand','colour'] });
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(data) {
     assert.ok(true, 'Promise is resolved');
@@ -63,14 +53,7 @@ it('should encode array counts parameter', function(assert) {
 
 it('should not encode string counts parameter', function(assert) {
   const p = db.search('fake', 'fake', 
-                    { counts: JSON.stringify(['brand','colour']) }, 
-                    function(err, data) {
-      assert.equal(err, null);
-      assert.equal(data.method, 'GET');
-      assert.equal(typeof data.headers, 'object');
-      assert.equal(typeof data.qs, 'object');
-      assert.equal(data.qs.counts, JSON.stringify(['brand','colour']));
-  });
+                    { counts: JSON.stringify(['brand','colour']) });
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(data) {
     assert.ok(true, 'Promise is resolved');
@@ -84,13 +67,7 @@ it('should not encode string counts parameter', function(assert) {
 });
 
 it('should encode array drilldown parameter', function(assert) {
-  const p = db.search('fake', 'fake', { drilldown: ['colour','red'] }, function(err, data) {
-      assert.equal(err, null);
-      assert.equal(data.method, 'GET');
-      assert.equal(typeof data.headers, 'object');
-      assert.equal(typeof data.qs, 'object');
-      assert.equal(data.qs.drilldown, JSON.stringify(['colour','red']));
-  });
+  const p = db.search('fake', 'fake', { drilldown: ['colour','red'] });
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(data) {
     assert.ok(true, 'Promise is resolved');
@@ -105,14 +82,7 @@ it('should encode array drilldown parameter', function(assert) {
 
 it('should not encode string drilldown parameter', function(assert) {
   const p = db.search('fake', 'fake', 
-                    { drilldown: JSON.stringify(['colour','red']) }, 
-                    function(err, data) {
-      assert.equal(err, null);
-      assert.equal(data.method, 'GET');
-      assert.equal(typeof data.headers, 'object');
-      assert.equal(typeof data.qs, 'object');
-      assert.equal(data.qs.drilldown, JSON.stringify(['colour','red']));
-  });
+                    { drilldown: JSON.stringify(['colour','red']) });
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(data) {
     assert.ok(true, 'Promise is resolved');
@@ -127,14 +97,7 @@ it('should not encode string drilldown parameter', function(assert) {
 
 it('should encode array group_sort parameter', function(assert) {
   const p = db.search('fake', 'fake', 
-                    { group_sort: ['-foo<number>','bar<string>'] }, 
-                    function(err, data) {
-      assert.equal(err, null);
-      assert.equal(data.method, 'GET');
-      assert.equal(typeof data.headers, 'object');
-      assert.equal(typeof data.qs, 'object');
-      assert.equal(data.qs.group_sort, JSON.stringify(['-foo<number>','bar<string>']));
-  });
+                    { group_sort: ['-foo<number>','bar<string>'] });
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(data) {
     assert.ok(true, 'Promise is resolved');
@@ -149,14 +112,7 @@ it('should encode array group_sort parameter', function(assert) {
 
 it('should not encode string group_sort parameter', function(assert) {
   const p = db.search('fake', 'fake', 
-                    { group_sort: JSON.stringify(['-foo<number>','bar<string>']) }, 
-                    function(err, data) {
-      assert.equal(err, null);
-      assert.equal(data.method, 'GET');
-      assert.equal(typeof data.headers, 'object');
-      assert.equal(typeof data.qs, 'object');
-      assert.equal(data.qs.group_sort, JSON.stringify(['-foo<number>','bar<string>']));
-  });
+                    { group_sort: JSON.stringify(['-foo<number>','bar<string>']) });
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(data) {
     assert.ok(true, 'Promise is resolved');
@@ -171,14 +127,7 @@ it('should not encode string group_sort parameter', function(assert) {
 
 it('should encode object ranges parameter', function(assert) {
   const p = db.search('fake', 'fake', 
-                    { ranges: {'price':'[0 TO 10]'} }, 
-                    function(err, data) {
-      assert.equal(err, null);
-      assert.equal(data.method, 'GET');
-      assert.equal(typeof data.headers, 'object');
-      assert.equal(typeof data.qs, 'object');
-      assert.equal(data.qs.ranges, JSON.stringify({'price':'[0 TO 10]'}));
-  });
+                    { ranges: {'price':'[0 TO 10]'} });
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(data) {
     assert.ok(true, 'Promise is resolved');
@@ -193,14 +142,7 @@ it('should encode object ranges parameter', function(assert) {
 
 it('should not encode string ranges parameter', function(assert) {
   const p = db.search('fake', 'fake', 
-                    { ranges: JSON.stringify({'price':'[0 TO 10]'}) }, 
-                    function(err, data) {
-      assert.equal(err, null);
-      assert.equal(data.method, 'GET');
-      assert.equal(typeof data.headers, 'object');
-      assert.equal(typeof data.qs, 'object');
-      assert.equal(data.qs.ranges, JSON.stringify({'price':'[0 TO 10]'}));
-  });
+                    { ranges: JSON.stringify({'price':'[0 TO 10]'}) });
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(data) {
     assert.ok(true, 'Promise is resolved');
@@ -215,14 +157,7 @@ it('should not encode string ranges parameter', function(assert) {
 
 it('should encode array sort parameter', function(assert) {
   const p = db.search('fake', 'fake', 
-                    { sort: ['-foo<number>','bar<string>'] }, 
-                    function(err, data) {
-      assert.equal(err, null);
-      assert.equal(data.method, 'GET');
-      assert.equal(typeof data.headers, 'object');
-      assert.equal(typeof data.qs, 'object');
-      assert.equal(data.qs.sort, JSON.stringify(['-foo<number>','bar<string>']));
-  });
+                    { sort: ['-foo<number>','bar<string>'] });
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(data) {
     assert.ok(true, 'Promise is resolved');
@@ -237,14 +172,7 @@ it('should encode array sort parameter', function(assert) {
 
 it('should not encode string sort parameter', function(assert) {
   const p = db.search('fake', 'fake', 
-                    { sort: JSON.stringify(['-foo<number>','bar<string>']) }, 
-                    function(err, data) {
-      assert.equal(err, null);
-      assert.equal(data.method, 'GET');
-      assert.equal(typeof data.headers, 'object');
-      assert.equal(typeof data.qs, 'object');
-      assert.equal(data.qs.sort, JSON.stringify(['-foo<number>','bar<string>']));
-  });
+                    { sort: JSON.stringify(['-foo<number>','bar<string>']) });
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(data) {
     assert.ok(true, 'Promise is resolved');
@@ -259,14 +187,7 @@ it('should not encode string sort parameter', function(assert) {
 
 it('should encode unencoded sort parameter', function(assert) {
   const p = db.search('fake', 'fake', 
-                    { sort: '-foo<number>' }, 
-                    function(err, data) {
-      assert.equal(err, null);
-      assert.equal(data.method, 'GET');
-      assert.equal(typeof data.headers, 'object');
-      assert.equal(typeof data.qs, 'object');
-      assert.equal(data.qs.sort, JSON.stringify('-foo<number>'));
-  });
+                    { sort: '-foo<number>' });
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(data) {
     assert.ok(true, 'Promise is resolved');
@@ -281,14 +202,7 @@ it('should encode unencoded sort parameter', function(assert) {
 
 it('should not encode encoded string sort parameter', function(assert) {
   const p = db.search('fake', 'fake', 
-                    { sort: JSON.stringify('-foo<number>') }, 
-                    function(err, data) {
-      assert.equal(err, null);
-      assert.equal(data.method, 'GET');
-      assert.equal(typeof data.headers, 'object');
-      assert.equal(typeof data.qs, 'object');
-      assert.equal(data.qs.sort, JSON.stringify('-foo<number>'));
-  });
+                    { sort: JSON.stringify('-foo<number>') });
   assert.ok(helpers.isPromise(p), 'returns Promise');
   p.then(function(data) {
     assert.ok(true, 'Promise is resolved');


### PR DESCRIPTION
## Overview

As pointed out in issue #112, by returning a Promise in most function calls in Nano 7 has unintended consequences for callback-only users. If the Promise rejects, the library user gets an ugly error.

This PR fixes that.

## Testing recommendations

```js
db.get('missingid', function(err, data) {
  console.log(err)
});
```

The above code should not give a Promise rejection warning.

## GitHub issue number

Issue #112 

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [x] Documentation reflects the changes;
