### PR TITLE
Only return Promise from `headDoc` when no callback is specified.

### DIFF
--- a/lib/nano.js
+++ b/lib/nano.js
@@ -504,25 +504,31 @@ module.exports = exports = function dbScope (cfg) {
 
     // http://docs.couchdb.org/en/latest/api/document/common.html#head--db-docid
     function headDoc (docName, callback) {
-      // this function doesn't pass on the Promise from relax because it needs
-      // to return the headers when resolving the Promise
-      return new Promise(function (resolve, reject) {
+      if (callback) {
         relax({
           db: dbName,
           doc: docName,
           method: 'HEAD',
           qs: {}
-        }, function (err, body, headers) {
-          if (callback) {
-            callback(err, body, headers)
-          }
-          if (err) {
-            reject(err)
-          } else {
-            resolve(headers)
-          }
-        })
-      })
+        }, callback);
+      } else {
+        // this function doesn't pass on the Promise from relax because it needs
+        // to return the headers when resolving the Promise
+        return new Promise(function (resolve, reject) {
+          relax({
+            db: dbName,
+            doc: docName,
+            method: 'HEAD',
+            qs: {}
+          }, function (err, body, headers) {
+            if (err) {
+              reject(err);
+            } else {
+              resolve(headers);
+            }
+          });
+        });
+      }
     }
 
     // http://docs.couchdb.org/en/latest/api/document/common.html#copy--db-docid

--- a/tests/unit/document/head.js
+++ b/tests/unit/document/head.js
@@ -1,0 +1,36 @@
+// Licensed under the Apache License, Version 2.0 (the 'License'); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+'use strict';
+
+const helpers = require('../../helpers/unit');
+const test = require('tape');
+const debug = require('debug')('nano/tests/unit/shared/error');
+
+const cli = helpers.mockClientDb(debug);
+const db = cli.use('foo');
+
+test('it should return a promise when no callback is specified', function (assert) {
+  var p = db.head('doc');
+  p.then((headers) => {
+    assert.equal(headers.statusCode, 200);
+    assert.end();
+  });
+});
+
+test('it should not return a promise when a callback is specified', function (assert) {
+  var p = db.head('doc', function(err, body, headers) {
+    assert.equal(headers.statusCode, 200);
+    assert.end();
+  });
+  assert.equal(typeof p, 'undefined');
+});


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
Only return a `Promise` from `headDoc` when no user callback is specified.
<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations
Added additional unit tests.
<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [x] Documentation reflects the changes;