### PR TITLE
keys can be set as array

### DIFF
--- a/lib/nano.d.ts
+++ b/lib/nano.d.ts
@@ -908,7 +908,7 @@ declare namespace nano {
     key?: string;
 
     // Return only documents that match the specified keys.
-    keys?: string; // This can be string[] too ???
+    keys?: string | string[]; 
 
     // Limit the number of the returned documents to the specified number.
     limit?: number;


### PR DESCRIPTION
Hi,

just a small change, in the types there is the following line:
`
    // Return only documents that match the specified keys.
    keys?: string; // This can be string[] too ???
`

In js, we pass keys as array so we should be able to do it in TypeScript too

