### PR TITLE
Fix for Issue148 - handling of drilldown parameter for search

### DIFF
--- a/README.md
+++ b/README.md
@@ -918,6 +918,15 @@ alice.search('characters', 'happy_ones', { q: 'cat' }).then((doc) => {
 });
 ```
 
+or
+
+```js
+const drilldown = [['author', 'Dickens']['publisher','Penguin']]
+alice.search('inventory', 'books', { q: '*:*', drilldown: drilldown }).then((doc) => {
+  console.log(doc);
+});
+```
+
 Check out the tests for a fully functioning example.
 
 ### db.searchAsStream(designname, searchname, params)

--- a/lib/nano.js
+++ b/lib/nano.js
@@ -275,6 +275,10 @@ module.exports = exports = function dbScope (cfg) {
       req.body = querystring.stringify(opts.form).toString('utf8')
     }
 
+    // ask request to render query string arrays as repeated values e.g.
+    // ?drilldown=["author","Dickens"]&drilldown=["publisher","Penguin"]
+    req.qsStringifyOptions = { arrayFormat: 'repeat' }
+
     log(req)
 
     if (opts.stream) {
@@ -621,7 +625,7 @@ module.exports = exports = function dbScope (cfg) {
 
       // Several search parameters must be JSON-encoded; but since this is an
       // object API, several parameters need JSON endoding.
-      const paramsToEncode = ['counts', 'drilldown', 'group_sort', 'ranges', 'sort']
+      const paramsToEncode = ['counts', 'group_sort', 'ranges', 'sort']
       paramsToEncode.forEach(function (param) {
         if (param in qs1) {
           if (typeof qs1[param] !== 'string') {
@@ -636,6 +640,25 @@ module.exports = exports = function dbScope (cfg) {
           }
         }
       })
+
+      // the drilldown parameter needs special treatment. It can either be:
+      // - a single array of strings e.g. ['author', 'Dickens']
+      // - an array of arrays e.g. [['author','Dickens']['publisher','Penguin']]
+      // The former should be JSON.stringified the latter should be an array of
+      // JSON.stringified arrays(!).
+      if (qs1['drilldown']) {
+        // if this is an array of arrays
+        if (Array.isArray(qs1['drilldown']) &&
+            qs1['drilldown'].length > 0 &&
+            Array.isArray(qs1['drilldown'][0])) {
+          // JSON stringify each element of the array
+          qs1['drilldown'] = qs1['drilldown'].map(function (val) {
+            return JSON.stringify(val)
+          })
+        } else if (Array.isArray(qs1['drilldown'])) {
+          qs1['drilldown'] = JSON.stringify(qs1['drilldown'])
+        }
+      }
 
       if (qs1 && qs1.keys) {
         const body = {keys: qs1.keys}

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "tape": "^4.6.2"
   },
   "scripts": {
+    "standard": "standard --fix",
     "test": "standard && npm run mocha",
     "mocha": "NOCK_OFF=true istanbul cover tape tests/*/*/*.js",
     "unmocked": "NOCK_OFF=true tape tests/*/*/*.js",

--- a/tests/helpers/unit.js
+++ b/tests/helpers/unit.js
@@ -94,6 +94,9 @@ helpers.unit = function (method, error) {
             delete req.httpAgent // ignore 'httpAgent' in deep equal assert
           }
 
+          // ignore qsStringifyOptions in object comparison
+          delete req.qsStringifyOptions
+
           assert.deepEqual(req, stub)
           assert.end()
         })

--- a/tests/intercept/design/search.js
+++ b/tests/intercept/design/search.js
@@ -99,6 +99,21 @@ it('should not encode string drilldown parameter', function (assert) {
   })
 })
 
+it('should encode array of arrays drilldown parameter', function (assert) {
+  const p = db.search('fake', 'fake', { drilldown: [['colour', 'red'], ['category', 'cake']] })
+  assert.ok(helpers.isPromise(p), 'returns Promise')
+  p.then(function (data) {
+    assert.ok(true, 'Promise is resolved')
+    assert.equal(data.method, 'GET')
+    assert.equal(typeof data.headers, 'object')
+    console.log(data.headers)
+    assert.equal(typeof data.qs, 'object')
+    assert.end()
+  }).catch(function () {
+    assert.ok(true, 'Promise is rejected')
+  })
+})
+
 it('should encode array group_sort parameter', function (assert) {
   const p = db.search('fake', 'fake',
     { group_sort: ['-foo<number>', 'bar<string>'] })


### PR DESCRIPTION
## Overview

Fixes handling of `drilldown` parameter. 

## Testing recommendations

Attempting a search with a `drilldown` with multiple filters should now work.

```js
var Nano = require('nano')
var nano = Nano(url)
var db = nano.db.use('books')
db.search('search', 'search', {
  q: '*:*',
  counts: ['publisher'],
  drilldown: [ ['publisher', 'Penguin'], ['author', 'Charles Dickens'] ]
}).then(console.log)
```

## GitHub issue number

Fixes issue #148 

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [x] Documentation reflects the changes;
