### PR TITLE
When docs are included, returned objects are expected to be documents

### DIFF
--- a/lib/nano.d.ts
+++ b/lib/nano.d.ts
@@ -1162,7 +1162,7 @@ declare namespace nano {
       id: string;
       key: string;
       value: V;
-      doc?: D;
+      doc?: D & Document;
     }>;
 
     // Number of documents in the database/view.


### PR DESCRIPTION
This pull request fixes the issue #152, current type is misleading  
