### PR TITLE
Update nano.d.ts

### DIFF
--- a/lib/nano.d.ts
+++ b/lib/nano.d.ts
@@ -1172,11 +1172,11 @@ declare namespace nano {
     update_seq: any;
   }
 
-  type MangoValue = number | string | Date | boolean;
+  type MangoValue = number | string | Date | boolean | null;
 
   // http://docs.couchdb.org/en/latest/api/database/find.html#selector-syntax
   interface MangoSelector {
-    [key: string]: MangoSelector | MangoValue | MangoValue[];
+    [key: string]: MangoSelector | MangoSelector[] | MangoValue | MangoValue[];
   }
 
   // http://docs.couchdb.org/en/latest/api/database/find.html#sort-syntax


### PR DESCRIPTION
Adding the option of a `MangoSelector[]` to the `MangoSelector` interface to find items that use an array such as $or
Also adding `null` for the `MangoValue` to allow querying for null value..
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-nano/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
