### PR TITLE
Added types for db.createIndex. Fixes #129

### DIFF
--- a/lib/nano.d.ts
+++ b/lib/nano.d.ts
@@ -182,6 +182,10 @@ declare namespace nano {
       params: DocumentFetchParams,
       callback?: Callback<DocumentFetchRevsResponse>
     ): Promise<DocumentFetchRevsResponse>;
+    // http://docs.couchdb.org/en/latest/api/database/find.html#db-index
+    createIndex(indexDef: CreateIndexRequest,
+                callback?:  Callback<CreateIndexResponse>
+    ): Promise<CreateIndexResponse>;
     multipart: Multipart<D>;
     attachment: Attachment;
     // http://docs.couchdb.org/en/latest/api/ddoc/render.html#get--db-_design-ddoc-_show-func
@@ -1268,6 +1272,39 @@ declare namespace nano {
 
     // Total execution time in milliseconds as measured by the database.
     execution_time_ms: number;
+  }
+
+  // http://docs.couchdb.org/en/latest/api/database/find.html#db-index
+  interface CreateIndexRequest {
+    // JSON object describing the index to create
+    index: {
+      // Array of field names following the sort syntax.
+      fields: SortOrder[],
+
+      // A selector to apply to documents at indexing time, creating a partial index.
+      partial_filter_selector?: MangoSelector
+    },
+
+    // Name of the design document in which the index will be created.
+    ddoc?: string
+
+    // Name of the index. If no name is provided, a name will be generated automatically.
+    name?: string,
+
+    // Can be "json" or "text". Defaults to json.
+    type?: 'json' | 'text'
+  }
+
+  // http://docs.couchdb.org/en/latest/api/database/find.html#db-index
+  interface CreateIndexResponse {
+    // Flag to show whether the index was created or one already exists. Can be “created” or “exists”.
+    result: string,
+
+    // Id of the design document the index was created in.
+    id: string,
+
+    // Name of the index created.
+    name: string
   }
 }
 

--- a/lib/nano.d.ts
+++ b/lib/nano.d.ts
@@ -1295,7 +1295,7 @@ declare namespace nano {
     type?: 'json' | 'text',
 
     // This field sets whether the created index will be a partitioned or global index.
-    partitioned: boolean
+    partitioned?: boolean
   }
 
   // http://docs.couchdb.org/en/latest/api/database/find.html#db-index

--- a/lib/nano.d.ts
+++ b/lib/nano.d.ts
@@ -1292,7 +1292,10 @@ declare namespace nano {
     name?: string,
 
     // Can be "json" or "text". Defaults to json.
-    type?: 'json' | 'text'
+    type?: 'json' | 'text',
+
+    // This field sets whether the created index will be a partitioned or global index.
+    partitioned: boolean
   }
 
   // http://docs.couchdb.org/en/latest/api/database/find.html#db-index


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Just created the types for the createIndex function (the request and the response).
The code was not modified.

## GitHub issue number

Fixes #129.
