### PR TITLE
fix: add replication to dbScope ts interface

### DIFF
--- a/lib/nano.d.ts
+++ b/lib/nano.d.ts
@@ -59,6 +59,11 @@ declare namespace nano {
   }
 
   interface DatabaseScope {
+    replication: {
+        enable(source, target, opts0, callback0?): any;
+        disable(id, rev, opts0, callback0?): any;
+        query(id, opts0, callback0?): any;
+    };
     // http://docs.couchdb.org/en/latest/api/database/common.html#put--db
     create(name: string, params?: DatabaseCreateParams, callback?: Callback<DatabaseCreateResponse>): Promise<DatabaseCreateResponse>;
     // http://docs.couchdb.org/en/latest/api/database/common.html#get--db


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
The nano lib dbScope has a replication object with a few functions. The function definition is missing from the nano.d.ts file. I added them so typescript should not throw error when using them. The definitions can be improved with explicit types, but I didn't want to define only a few types, and I don't exactly know all of the qs options.

## Testing recommendations
Any typescript project that uses dbScope.replication functions should no longer throw an error
<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Checklist

- [x] Code is written and works correctly;
- [-] Changes are covered by tests;
- [x] Documentation reflects the changes;
