### PR TITLE
fix(nano.d.ts): fix MangoSelector typings

### DIFF
--- a/lib/nano.d.ts
+++ b/lib/nano.d.ts
@@ -1197,9 +1197,32 @@ declare namespace nano {
   type MangoValue = number | string | Date | boolean | null;
 
   // http://docs.couchdb.org/en/latest/api/database/find.html#selector-syntax
-  interface MangoSelector {
-    [key: string]: MangoSelector | MangoValue | MangoValue[];
+
+  enum ConditionOperands {
+    $lt = '$lt',
+    $lte = '$lte',
+    $eq = '$eq',
+    $ne = '$ne',
+    $gte = '$gte',
+    $gt = '$gt'
   }
+
+  enum ArrayFieldOperands {
+    $in = '$in',
+    $nin = '$nin'
+  }
+
+  enum CombinationOperands {
+      $or = '$or',
+      $and = '$and',
+      $nor = '$nor',
+      $all = '$all'
+  }
+
+  type MangoSelector = { [key: string]: MangoSelector | MangoValue | MangoValue[]; }
+    | Partial<{ [key in ConditionOperands]: MangoValue; }>
+    | Partial<{ [key in ArrayFieldOperands]: MangoValue[] }>
+    | Partial<{ [key in CombinationOperands]: MangoSelector[] }>
 
   // http://docs.couchdb.org/en/latest/api/database/find.html#sort-syntax
   type SortOrder = string | string[] | { [key: string]: 'asc' | 'desc' };


### PR DESCRIPTION
## Overview
Previous MangoSelector type definitions throwed TS2322 error, when you tried to build moreless complex selector (for example with $or, $and operands).
PR fixes type checking of this cases.

## Testing recommendations
PR doesn't affect on implementation.

## GitHub issue number
Fixes #159 

## Checklist

- [✓] Code is written and works correctly;
- [✗] Changes are covered by tests;
- [✓] Documentation reflects the changes;
