### PR TITLE
get attachment should return a Buffer

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,5 @@
 tests
 scripts
+examples
+coverage
+.github

--- a/lib/nano.d.ts
+++ b/lib/nano.d.ts
@@ -350,14 +350,14 @@ declare namespace nano {
       contenttype: string,
       params: any
     ): Request
-    get(docname: string, attname: string, callback?: Callback<any>): Promise<any>;
+    get(docname: string, attname: string, callback?: Callback<Buffer>): Promise<Buffer>;
     getAsStream(docname: string, attname: string): Request;
     get(
       docname: string,
       attname: string,
       params: any,
-      callback?: Callback<any>
-    ): Promise<any>;
+      callback?: Callback<Buffer>
+    ): Promise<Buffer>;
     destroy(docname: string, attname: string, callback?: Callback<any>): Promise<any>;
     destroy(
       docname: string,

--- a/lib/nano.js
+++ b/lib/nano.js
@@ -226,7 +226,7 @@ module.exports = exports = function dbScope (cfg) {
     }
 
     // prevent bugs where people set encoding when piping
-    if (opts.encoding !== undefined && callback) {
+    if (opts.encoding !== undefined) {
       req.encoding = opts.encoding
       delete req.headers['content-type']
       delete req.headers.accept


### PR DESCRIPTION
As mentioned in issue #170, the Promise variant of the library returned a String instead of a Buffer when fetching binary attachments. This is fixed by removing the content-type and accept headers in the requests (as was done for the callback variant).