### PR TITLE
_local support added #167

### DIFF
--- a/lib/nano.js
+++ b/lib/nano.js
@@ -211,7 +211,7 @@ module.exports = exports = function dbScope (cfg) {
     if (opts.path) {
       req.uri += '/' + opts.path
     } else if (opts.doc) {
-      if (!/^_design/.test(opts.doc)) {
+      if (!/^_design|_local/.test(opts.doc)) {
         // http://wiki.apache.org/couchdb/HTTP_Document_API#Naming.2FAddressing
         req.uri += '/' + encodeURIComponent(opts.doc)
       } else {


### PR DESCRIPTION
## Overview

Currently the `get` does not support the retrieval of document stored in the couchdb local database which is prefixed with `_local/`

## Testing recommendations

See #167 in which the proposed change was mentioned.

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [x] Documentation reflects the changes;
