### PR TITLE
Bugfix (nano.d.ts): DocumentScope.atomic method returns a customizable data structure

### DIFF
--- a/lib/nano.d.ts
+++ b/lib/nano.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Tim Jacobi <https://github.com/timjacobi>
 //                 Kovács Vince <https://github.com/vincekovacs>
 //                 Glynn Bird <https://github.com/glynnbird>
+//                 Kyle Chine <https://github.com/kylechine>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/lib/nano.d.ts
+++ b/lib/nano.d.ts
@@ -209,20 +209,20 @@ declare namespace nano {
       callback?: Callback<any>
     ): Promise<any>;
     // http://docs.couchdb.org/en/latest/api/ddoc/render.html#put--db-_design-ddoc-_update-func-docid
-    atomic(
+    atomic<R>(
       designname: string,
       updatename: string,
       docname: string,
-      callback?: Callback<OkResponse>
-    ): Promise<OkResponse>;
+      callback?: Callback<R>
+    ): Promise<R>;
     // http://docs.couchdb.org/en/latest/api/ddoc/render.html#put--db-_design-ddoc-_update-func-docid
-    atomic(
+    atomic<R>(
       designname: string,
       updatename: string,
       docname: string,
       body: any,
-      callback?: Callback<OkResponse>
-    ): Promise<OkResponse>;
+      callback?: Callback<R>
+    ): Promise<R>;
     // http://docs.couchdb.org/en/latest/api/ddoc/render.html#put--db-_design-ddoc-_update-func-docid
     updateWithHandler(
       designname: string,


### PR DESCRIPTION
## Overview

The return value of `DocumentScope.atomic` method should be a user-customizable structure instead of `OkResponse`.

## Details

According to the CouchDB documentation:
<http://docs.couchdb.org/en/latest/api/ddoc/render.html#put--db-_design-ddoc-_update-func-docid>

The update function response is customizable and should be given by user. But in current version of type definition, the return value is `Promise<OkResponse>`

```typescript
atomic(
      designname: string,
      updatename: string,
      docname: string,
      callback?: Callback<OkResponse>
): Promise<OkResponse>;

atomic(
      designname: string,
      updatename: string,
      docname: string,
      body: any,
      callback?: Callback<OkResponse>
): Promise<OkResponse>;

interface OkResponse {
  // Operation status
  ok: boolean;
}
```

Which is incorrect.

## Solution

I changed the method definition to `atomic<R>`, in which <R> means customized Response data structure.

```typescript
atomic<R>(
      designname: string,
      updatename: string,
      docname: string,
      callback?: Callback<R>
    ): Promise<R>;

atomic<R>(
      designname: string,
      updatename: string,
      docname: string,
      body: any,
      callback?: Callback<R>
    ): Promise<R>;
```