### PR TITLE
Fix for issue 189

### DIFF
--- a/lib/nano.d.ts
+++ b/lib/nano.d.ts
@@ -1271,7 +1271,7 @@ declare namespace nano {
   interface MangoResponse<D> {
     // Array of documents matching the search. In each matching document, the fields specified in
     // the fields part of the request body are listed, along with their values.
-    docs: D[];
+    docs: (D & {_id: string, _rev:string})[];
 
     // A string that enables you to specify which page of results you require. Used for paging through result sets.
     bookmark?: string;


### PR DESCRIPTION
## Overview
Fix for issue #189 
"Typescript: MangoResponse - The type definition does not allow for accessing the "_id" an "_rev" fields"

## Testing recommendations

The query response of a mango query, should no allow access to the "_id" and "_rev" field for every returned document.

## GitHub issue number

Fixes #189 


