### PR TITLE
change bulk() return type

### DIFF
--- a/lib/nano.d.ts
+++ b/lib/nano.d.ts
@@ -161,7 +161,7 @@ declare namespace nano {
     ): Promise<DocumentCopyResponse>;
     // http://docs.couchdb.org/en/latest/api/document/common.html#delete--db-docid
     destroy(docname: string, rev: string, callback?: Callback<DocumentDestroyResponse>): Promise<DocumentDestroyResponse>;
-    bulk(docs: BulkModifyDocsWrapper, callback?: Callback<DocumentInsertResponse[]>): Promise<DocumentInsertResponse[]>;
+    bulk(docs: BulkModifyDocsWrapper, callback?: Callback<DocumentBulkResponse[]>): Promise<DocumentBulkResponse[]>;
     bulk(docs: BulkModifyDocsWrapper, params: any, callback?: Callback<DocumentInsertResponse[]>): Promise<DocumentInsertResponse[]>;
     // http://docs.couchdb.org/en/latest/api/database/bulk-api.html#get--db-_all_docs
     list(callback?: Callback<DocumentListResponse<D>>): Promise<DocumentListResponse<D>>;
@@ -768,6 +768,21 @@ declare namespace nano {
 
   interface DocumentResponseRow<D> extends DocumentResponseRowMeta {
     doc?: D & Document;
+  }
+
+  // http://docs.couchdb.org/en/latest/api/database/bulk-api.html#post--db-_bulk_docs
+  interface DocumentBulkResponse {
+    // Document ID. Available in all cases
+    id: string;
+
+    // New document revision token. Available if document has saved without errors.
+    rev?: string;
+
+    // Error type. Available if response code is 4xx
+    error?: string;
+
+    // Error reason. Available if response code is 4xx
+    reason?: string;
   }
 
   // http://docs.couchdb.org/en/latest/api/database/common.html#post--db


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

Changes return type of the `bulk()` method to align with the response specified in the [CouchDB API](http://docs.couchdb.org/en/latest/api/database/bulk-api.html#post--db-_bulk_docs)

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
Manually check types against API.

## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-nano/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->
Fixes #198

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
