### PR TITLE
Make sure nano works with _local docs

### DIFF
--- a/lib/nano.js
+++ b/lib/nano.js
@@ -225,7 +225,7 @@ module.exports = exports = function dbScope (cfg) {
     if (opts.path) {
       req.uri += '/' + opts.path
     } else if (opts.doc) {
-      if (!/^_design/.test(opts.doc)) {
+      if (!/^_design|_local/.test(opts.doc)) {
         // http://wiki.apache.org/couchdb/HTTP_Document_API#Naming.2FAddressing
         req.uri += '/' + encodeURIComponent(opts.doc)
       } else {

--- a/test/document.get.test.js
+++ b/test/document.get.test.js
@@ -101,7 +101,7 @@ test('check request can fetch local documents - db.get', async () => {
 
   // test GET /db/_local/id
   const db = nano.db.use('db')
-  const p = await db.get('_local/_id')
+  const p = await db.get('_local/id')
   expect(p).toStrictEqual(response)
   expect(scope.isDone()).toBe(true)
 })

--- a/test/document.get.test.js
+++ b/test/document.get.test.js
@@ -91,3 +91,17 @@ test('should detect missing parameters (callback) - db.get', () => {
     })
   })
 })
+
+test('check request can fetch local documents - db.get', async () => {
+  // mocks
+  const response = { _id: '_local/id', _rev: '1-123', a: 1 }
+  const scope = nock(COUCH_URL)
+    .get('/db/_local/id')
+    .reply(200, response)
+
+  // test GET /db/_local/id
+  const db = nano.db.use('db')
+  const p = await db.get('_local/_id')
+  expect(p).toStrictEqual(response)
+  expect(scope.isDone()).toBe(true)
+})

--- a/test/document.insert.test.js
+++ b/test/document.insert.test.js
@@ -130,3 +130,35 @@ test('should be able to handle missing database - POST /db - db.insert', async (
   await expect(db.insert(doc)).rejects.toThrow('Database does not exist.')
   expect(scope.isDone()).toBe(true)
 })
+
+test('should be able to insert document with _local id - PUT /db/_local/id - db.insert', async () => {
+  // mocks
+  const doc = { a: 1, b: 2 }
+  const response = { ok: true, id: '_local/myid', rev: '1-123' }
+
+  const scope = nock(COUCH_URL)
+    .put('/db/_local/myid', doc)
+    .reply(200, response)
+
+  // test PUT /db
+  const db = nano.db.use('db')
+  const p = await db.insert(doc, '_local/myid')
+  expect(p).toStrictEqual(response)
+  expect(scope.isDone()).toBe(true)
+})
+
+test('should be able to insert document with local id in object - POST /db - db.insert', async () => {
+  // mocks
+  const doc = { _id: '_local/myid', a: 1, b: 2 }
+  const response = { ok: true, id: '_local/myid', rev: '1-123' }
+
+  const scope = nock(COUCH_URL)
+    .post('/db', doc)
+    .reply(200, response)
+
+  // test POST /db
+  const db = nano.db.use('db')
+  const p = await db.insert(doc)
+  expect(p).toStrictEqual(response)
+  expect(scope.isDone()).toBe(true)
+})


### PR DESCRIPTION
This PR https://github.com/apache/couchdb-nano/pulls kindly fixed nano's ability to handle _local documents. Unfortunately there were no tests, so this PR cherry-pick's the commit that fixed Nano and some new tests to check that Nano isn't mangling document ids of the form `_local/id`.

## Overview

An exception has to be made for document ids of the form `_local/id` just like, otherwise they get URL encoded and mangled.

## Testing recommendations

npm run jest

## GitHub issue number

https://github.com/apache/couchdb-nano/issues/167

## Related Pull Requests

https://github.com/apache/couchdb-nano/pull/176

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [x] Documentation reflects the changes;
