### PR TITLE
ensure TypeScript definitions are sound during testing

### DIFF
--- a/lib/nano.d.ts
+++ b/lib/nano.d.ts
@@ -304,7 +304,7 @@ declare namespace nano {
     find(query: MangoQuery, callback?: Callback<MangoResponse<D>>): Promise <MangoResponse<D>>;
     server: ServerScope;
     //https://docs.couchdb.org/en/latest/partitioned-dbs/index.html
-    partitionInfo(partitionKey: string, callback?: Callback<PartitionInfoResponse<D>>): Promise <PartitionInfoResponse>;
+    partitionInfo(partitionKey: string, callback?: Callback<PartitionInfoResponse>): Promise <PartitionInfoResponse>;
     partitionedList(partitionKey: string, params?: DocumentListParams, callback?: Callback<DocumentListResponse<D>>): Promise<DocumentListResponse<D>>;
     partitionedListAsStream(partitionKey: string, params?: DocumentListParams): Request;
     partitionedFind(partitionKey: string, query: MangoQuery, callback?: Callback<MangoResponse<D>>): Promise <MangoResponse<D>>;
@@ -1083,8 +1083,8 @@ declare namespace nano {
 
     // Partition sizes
     sizes: {
-      active: integer;
-      external: integer;
+      active: number;
+      external: number;
     }
 
     // Partition name

--- a/package-lock.json
+++ b/package-lock.json
@@ -974,9 +974,9 @@
       }
     },
     "@types/node": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.0.tgz",
-      "integrity": "sha512-GnZbirvmqZUzMgkFn70c74OQpTTUcCzlhQliTzYjQMqg+hVKcDnxdL19Ne3UdYzdMA/+W3eb646FWn/ZaT1NfQ=="
+      "version": "13.7.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.1.tgz",
+      "integrity": "sha512-Zq8gcQGmn4txQEJeiXo/KiLpon8TzAl0kmKH4zdWctPj05nWwp1ClMdAVEloqrQKfaC48PNLdgN/aVaLqUrluA=="
     },
     "@types/request": {
       "version": "2.48.4",
@@ -1177,15 +1177,6 @@
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
-    },
-    "async": {
-      "version": "2.6.2",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/wcp-wdp-npm-virtual/async/-/async-2.6.2.tgz",
-      "integrity": "sha1-GDMOp+bjE4h/XS8qkEusb+TdU4E=",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.17.11"
-      }
     },
     "asynckit": {
       "version": "0.4.0",
@@ -4946,12 +4937,6 @@
         "path-exists": "^3.0.0"
       }
     },
-    "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-      "dev": true
-    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -7020,6 +7005,12 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "typescript": {
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
+      "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
+      "dev": true
     },
     "union-value": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -24,14 +24,14 @@
     "request": "^2.88.0"
   },
   "devDependencies": {
-    "async": "^2.6.2",
     "jest": "^25.1.0",
     "nock": "^11.7.2",
-    "standard": "^14.3.1"
+    "standard": "^14.3.1",
+    "typescript": "^3.7.5"
   },
   "scripts": {
     "standard": "standard --fix",
-    "test": "standard && npm run jest",
+    "test": "standard && tsc lib/nano.d.ts && npm run jest",
     "jest": "jest test/* --coverage"
   },
   "main": "./lib/nano.js",
@@ -40,9 +40,7 @@
     "node": ">=10"
   },
   "pre-commit": [
-    "mocked",
-    "test",
-    "checkcoverage"
+    "test"
   ],
   "standard": {
     "env": [


### PR DESCRIPTION
I noticed the TypeScript definitions weren't syntactically correct, so I fixed them and ensured that the `npm run test` command checks the TypeScript syntax too.

## Overview

Fix TypeScript definition and ensure that the tests can't pass with invalid TypeScript definitions in the future.

## Testing recommendations

npm run test

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [x] Documentation reflects the changes;
