### PR TITLE
allow fetch to return errors as well as successes - fixes issue #203

### DIFF
--- a/lib/nano.d.ts
+++ b/lib/nano.d.ts
@@ -181,13 +181,13 @@ declare namespace nano {
       callback?: Callback<DocumentFetchResponse<D>>
     ): Promise<DocumentFetchResponse<D>>;
     // http://docs.couchdb.org/en/latest/api/database/bulk-api.html#post--db-_all_docs
-    fetchRevs(docnames: BulkFetchDocsWrapper, callback?: Callback<DocumentFetchRevsResponse>): Promise<DocumentFetchRevsResponse>;
+    fetchRevs(docnames: BulkFetchDocsWrapper, callback?: Callback<DocumentFetchRevsResponse<D>>): Promise<DocumentFetchRevsResponse<D>>;
     // http://docs.couchdb.org/en/latest/api/database/bulk-api.html#post--db-_all_docs
     fetchRevs(
       docnames: BulkFetchDocsWrapper,
       params: DocumentFetchParams,
-      callback?: Callback<DocumentFetchRevsResponse>
-    ): Promise<DocumentFetchRevsResponse>;
+      callback?: Callback<DocumentFetchRevsResponse<D>>
+    ): Promise<DocumentFetchRevsResponse<D>>;
     // http://docs.couchdb.org/en/latest/api/database/find.html#db-index
     createIndex(indexDef: CreateIndexRequest,
                 callback?:  Callback<CreateIndexResponse>
@@ -1032,21 +1032,24 @@ declare namespace nano {
     start_key_doc_id?: string;
     update_seq?: boolean;
   }
+  interface DocumentLookupFailure {
+    key: string;
+    error: string;
+  }
 
   interface DocumentFetchResponse<D> {
     offset: number;
-    rows: Array<DocumentResponseRow<D>>;
+    rows: Array<DocumentResponseRow<D> | DocumentLookupFailure>;
     total_rows: number;
     update_seq?: number;
   }
 
-  interface DocumentFetchRevsResponse {
+  interface DocumentFetchRevsResponse<D> {
     offset: number;
-    rows: DocumentResponseRowMeta[];
+    rows: Array<DocumentResponseRow<D> | DocumentLookupFailure>;
     total_rows: number;
     update_seq?: number;
   }
-
 
   interface DocumentSearchResponse<V> {
 


### PR DESCRIPTION
## Overview

Fixes TypeScript for fetch and fetchRevs functions to allow them to return a mixture of error or success responses.

## Testing recommendations

tsc lib/nano.d.ts

No code changes

## GitHub issue number

Issue #203 

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [x] Documentation reflects the changes;
