### PR TITLE
improve TypeScript definitions for Mango selectors - fixes issue #202

### DIFF
--- a/lib/nano.d.ts
+++ b/lib/nano.d.ts
@@ -1266,35 +1266,15 @@ declare namespace nano {
     update_seq: any;
   }
 
-  type MangoValue = number | string | Date | boolean | null;
-
   // http://docs.couchdb.org/en/latest/api/database/find.html#selector-syntax
-
-  enum ConditionOperands {
-    $lt = '$lt',
-    $lte = '$lte',
-    $eq = '$eq',
-    $ne = '$ne',
-    $gte = '$gte',
-    $gt = '$gt'
+  type MangoValue = number | string | Date | boolean | object | null;
+  type MangoOperator = '$lt' | '$lte' | '$eq' | '$ne' | '$gte' | '$gt' |
+                    '$exists' | '$type' | 
+                    '$in' | '$nin' | '$size' | '$mod' | '$regex' |
+                    '$or' | '$and' | '$nor' | '$not' | '$all' | '$allMatch' | '$elemMatch';
+  type MangoSelector = {
+    [K in MangoOperator]: MangoSelector | MangoValue | MangoValue[];
   }
-
-  enum ArrayFieldOperands {
-    $in = '$in',
-    $nin = '$nin'
-  }
-
-  enum CombinationOperands {
-      $or = '$or',
-      $and = '$and',
-      $nor = '$nor',
-      $all = '$all'
-  }
-
-  type MangoSelector = { [key: string]: MangoSelector | MangoValue | MangoValue[]; }
-    | Partial<{ [key in ConditionOperands]: MangoValue; }>
-    | Partial<{ [key in ArrayFieldOperands]: MangoValue[] }>
-    | Partial<{ [key in CombinationOperands]: MangoSelector[] }>
 
   // http://docs.couchdb.org/en/latest/api/database/find.html#sort-syntax
   type SortOrder = string | string[] | { [key: string]: 'asc' | 'desc' };


### PR DESCRIPTION
## Overview

Improve Mango TypeScript definitions which didn't correctly model

- all the possible $ operators
- the ability to have an operator within an operator 

## Testing recommendations

Passes tsc 

## GitHub issue number

https://github.com/apache/couchdb-nano/issues/202

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [x] Documentation reflects the changes;
