### PR TITLE
switch to CouchDB 3 for the Travis tests - no admin party in CouchDB 3

### DIFF
--- a/scripts/run_couchdb_on_travis.sh
+++ b/scripts/run_couchdb_on_travis.sh
@@ -2,12 +2,13 @@
 
 if [ ! -z $TRAVIS ]; then
 	# Install CouchDB Master
-	echo "Starting CouchDB 2.0 Docker"
-	docker run --ulimit nofile=2048:2048 -d -p 5984:5984 couchdb --with-haproxy \
-	    --with-admin-party-please -n 1
+	echo "Starting CouchDB 3 Docker"
+	docker run --ulimit nofile=2048:2048 -d -p 5984:5984 \
+	    --env COUCHDB_USER=admin --env COUCHDB_PASSWORD=admin \
+	    couchdb --with-haproxy -n 1
 
 	# wait for couchdb to start
-	while [ '200' != $(curl -s -o /dev/null -w %{http_code} http://127.0.0.1:5984) ]; do
+	while [ '200' != $(curl -s -o /dev/null -w %{http_code} http://admin:admin@127.0.0.1:5984/_all_dbs) ]; do
 	  echo waiting for couch to load... ;
 	  sleep 1;
 	done

--- a/scripts/stop_couchdb_on_travis.sh
+++ b/scripts/stop_couchdb_on_travis.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if [ ! -z $TRAVIS ]; then
-  echo "Stopping CouchDB 2.0 Docker"
+  echo "Stopping CouchDB 3 Docker"
   docker stop $(docker ps -a -q)
   docker rm $(docker ps -a -q)
 fi

--- a/test/notnocked.test.js
+++ b/test/notnocked.test.js
@@ -11,7 +11,7 @@
 // the License.
 
 const Nano = require('..')
-const COUCH_URL = 'http://localhost:5984'
+const COUCH_URL = 'http://admin:admin@localhost:5984'
 const nano = Nano(COUCH_URL)
 const dbName = 'notnocked' + new Date().getTime()
 let db


### PR DESCRIPTION
## Overview

CouchDB 3 is released 💯 , so the Travis tests need to use that as a target. This happens automatically, because travis pulls `couchdb:latest`, but CouchDB 3 has no "admin party", so we need to create an admin user otherwise nothing works.

## Testing recommendations

```
export TRAVIS=true
npm run test
```

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [x] Documentation reflects the changes;
