### PR TITLE
stricter TypeScript definitions with tsc --strict, fixes issue #209

### DIFF
--- a/lib/nano.d.ts
+++ b/lib/nano.d.ts
@@ -45,13 +45,13 @@ declare namespace nano {
     // http://docs.couchdb.org/en/latest/api/server/common.html#get--_db_updates
     updates(params: UpdatesParams, callback?: Callback<DatabaseUpdatesResponse>): Promise<DatabaseUpdatesResponse>;
     followUpdates(params?: any): FollowEmitter;
-    followUpdates(callback: Callback<any>);
-    followUpdates(params: any, callback: Callback<any>);
+    followUpdates(callback: Callback<any>): void;
+    followUpdates(params: any, callback: Callback<any>): void;
     uuids(num: number, callback?: Callback<any>): Promise<UUIDObject>;
   }
 
   interface FollowEmitter extends EventEmitter {
-    follow();
+    follow(): void;
   }
   
   interface UUIDObject {
@@ -66,9 +66,9 @@ declare namespace nano {
 
   interface DatabaseScope {
     replication: {
-        enable(source, target, opts0, callback0?): any;
-        disable(id, rev, opts0, callback0?): any;
-        query(id, opts0, callback0?): any;
+        enable(source: string, target: string, opts0: object, callback0?: Callback<DatabaseCreateResponse>): Promise<DatabaseCreateResponse>;
+        disable(id:string, rev: string, opts0: object, callback0?: Callback<DatabaseCreateResponse>): Promise<DatabaseCreateResponse>;
+        query(id: string, opts0: object, callback0?: Callback<DatabaseGetResponse>): Promise<DatabaseGetResponse>;
     };
     // http://docs.couchdb.org/en/latest/api/database/common.html#put--db
     create(name: string, params?: DatabaseCreateParams, callback?: Callback<DatabaseCreateResponse>): Promise<DatabaseCreateResponse>;
@@ -105,10 +105,10 @@ declare namespace nano {
     // http://docs.couchdb.org/en/latest/api/database/compact.html#post--db-_compact
     changesAsStream(name: string, params: DatabaseChangesParams): Request;
     follow(source: string, params?: DatabaseScopeFollowUpdatesParams): FollowEmitter;
-    follow(source: string, params: DatabaseScopeFollowUpdatesParams, callback: Callback<any>);
+    follow(source: string, params: DatabaseScopeFollowUpdatesParams, callback: Callback<any>): void;
     followUpdates(params?: any): FollowEmitter;
-    followUpdates(params: DatabaseScopeFollowUpdatesParams, callback: Callback<any>);
-    followUpdates(callback: Callback<any>);
+    followUpdates(params: DatabaseScopeFollowUpdatesParams, callback: Callback<any>): void;
+    followUpdates(callback: Callback<any>): void;
     // http://docs.couchdb.org/en/latest/api/server/common.html#get--_db_updates
     updates(callback?: Callback<DatabaseUpdatesResponse>): Promise<DatabaseUpdatesResponse>;
     // http://docs.couchdb.org/en/latest/api/server/common.html#get--_db_updates
@@ -137,8 +137,8 @@ declare namespace nano {
     // http://docs.couchdb.org/en/latest/api/database/changes.html#get--db-_changes
     changes(params: DatabaseChangesParams, callback?: Callback<DatabaseChangesResponse>): Promise<DatabaseChangesResponse>;
     follow(params?: DocumentScopeFollowUpdatesParams): FollowEmitter;
-    follow(params: DocumentScopeFollowUpdatesParams, callback: Callback<any>);
-    follow(callback: Callback<any>);
+    follow(params: DocumentScopeFollowUpdatesParams, callback: Callback<any>): void;
+    follow(callback: Callback<any>): void;
     // http://docs.couchdb.org/en/latest/api/server/authn.html#cookie-authentication
     auth(username: string, userpass: string, callback?: Callback<DatabaseAuthResponse>): Promise<DatabaseAuthResponse>;
     // http://docs.couchdb.org/en/latest/api/server/authn.html#get--_session


### PR DESCRIPTION
## Overview

Although the Typescript definitions were checked with `tsc`, folks using `tsc --strict` in their projects were seeing some errors. So I've enabled `tsc --strict` in package.json which shows up the errors, which are also fixed.

## Testing recommendations

TypeScript users with `--strict` compilation will see errors go away.

## GitHub issue number

Fixes issue #209 

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [x] Documentation reflects the changes;
