### PR TITLE
improve MangoSelector TypeScript type - fixes issue #211

### DIFF
--- a/lib/nano.d.ts
+++ b/lib/nano.d.ts
@@ -1284,7 +1284,7 @@ declare namespace nano {
                     '$in' | '$nin' | '$size' | '$mod' | '$regex' |
                     '$or' | '$and' | '$nor' | '$not' | '$all' | '$allMatch' | '$elemMatch';
   type MangoSelector = {
-    [K in MangoOperator]: MangoSelector | MangoValue | MangoValue[];
+    [K in MangoOperator | string]: MangoSelector | MangoValue | MangoValue[];
   }
 
   // http://docs.couchdb.org/en/latest/api/database/find.html#sort-syntax


### PR DESCRIPTION
## Overview

As pointed out in issue #211, a MangoSeletor needs to be able to handle top-level strings so the TypeScript definition needs loosening a little to accept either a MangoOperator or just a string literal.

## Testing recommendations

```
tsc --strict lib/nano.d.ts
```

## GitHub issue number

#211 


## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [x] Documentation reflects the changes;
