### PR TITLE
Add string to View.map type

### DIFF
--- a/lib/nano.d.ts
+++ b/lib/nano.d.ts
@@ -501,7 +501,7 @@ declare namespace nano {
 
   type DocumentInfer<D> = (doc: D & Document) => void
   interface View<D> {
-    map?:DocumentInfer<D>;
+    map?: string | DocumentInfer<D>;
     reduce?: string | DocumentInfer<D>
     
   }


### PR DESCRIPTION
## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
Allow strings to be passed to View.map with a typed `DocumentScope` object. Not needing to cast a string to any.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
It's only a small typescript change, no actual behaviour changed.

## GitHub issue number
Fixes #219

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [X] Documentation reflects the changes;
