### PR TITLE
fix(nano.d.ts): add opts and callback for relax

### DIFF
--- a/lib/nano.d.ts
+++ b/lib/nano.d.ts
@@ -34,8 +34,8 @@ declare namespace nano {
     use<D>(db: string): DocumentScope<D>;
     scope<D>(db: string): DocumentScope<D>;
     request(opts: RequestOptions | string, callback?: Callback<any>): Promise<any>;
-    relax: Promise<any>;
-    dinosaur: Promise<any>;
+    relax(opts: RequestOptions | string, callback?: Callback<any>): Promise<any>;
+    dinosaur(opts: RequestOptions | string, callback?: Callback<any>): Promise<any>;
     // http://docs.couchdb.org/en/latest/api/server/authn.html#cookie-authentication
     auth(username: string, userpass: string, callback?: Callback<DatabaseAuthResponse>): Promise<DatabaseAuthResponse>;
     // http://docs.couchdb.org/en/latest/api/server/authn.html#get--_session

--- a/lib/nano.d.ts
+++ b/lib/nano.d.ts
@@ -33,7 +33,7 @@ declare namespace nano {
     db: DatabaseScope;
     use<D>(db: string): DocumentScope<D>;
     scope<D>(db: string): DocumentScope<D>;
-    request: Promise<any>;
+    request(opts: RequestOptions | string, callback?: Callback<any>): Promise<any>;
     relax: Promise<any>;
     dinosaur: Promise<any>;
     // http://docs.couchdb.org/en/latest/api/server/authn.html#cookie-authentication
@@ -412,11 +412,6 @@ declare namespace nano {
     url: string;
     db: string;
   }
-
-  type RequestFunction = (
-    options?: RequestOptions | string,
-    callback?: Callback<any>
-  ) => void;
 
   interface RequestOptions {
     db?: string;


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
Adds opts and callback to nano.request type definition. 
<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations
Changes to typescript definitions only, no code modified. 
<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## GitHub issue number
N/A
<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-nano/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Related Pull Requests
N/A
<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [x] Documentation reflects the changes;