### PR TITLE
Fix nano.d.ts: Add FollowEmitter.stop() to typescript declaration file

### DIFF
--- a/lib/nano.d.ts
+++ b/lib/nano.d.ts
@@ -54,6 +54,7 @@ declare namespace nano {
 
   interface FollowEmitter extends EventEmitter {
     follow(): void;
+    stop(): void;
   }
 
   interface UUIDObject {


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
The feed of `cloudant-follow` can be stopped by calling `stop()` method. It is missing from the `nano.d.ts` file.
https://www.npmjs.com/package/cloudant-follow#events

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

Changes to typescript definitions only, no code modified.

## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-nano/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->
NA.
## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->
NA.
## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [x] Documentation reflects the changes;
