### PR TITLE
Fix nano.d.ts: Patch typescript declaration file

### DIFF
--- a/lib/nano.d.ts
+++ b/lib/nano.d.ts
@@ -57,7 +57,7 @@ declare namespace nano {
   }
 
   interface UUIDObject {
-    uuids: string[]
+    uuids: string[];
   }
 
   // https://docs.couchdb.org/en/stable/api/server/common.html#api-server-root
@@ -814,6 +814,7 @@ declare namespace nano {
     value: {
       rev: string;
     };
+    error?: string;
   }
 
   interface DocumentResponseRow<D> extends DocumentResponseRowMeta {
@@ -1172,7 +1173,7 @@ declare namespace nano {
     sort?: string | string[];
 
     // Do not wait for the index to finish building to return results.
-    stale?: boolean
+    stale?: boolean;
   }
 
   // http://docs.couchdb.org/en/latest/api/ddoc/views.html#get--db-_design-ddoc-_view-view
@@ -1291,7 +1292,7 @@ declare namespace nano {
                     '$in' | '$nin' | '$size' | '$mod' | '$regex' |
                     '$or' | '$and' | '$nor' | '$not' | '$all' | '$allMatch' | '$elemMatch';
   type MangoSelector = {
-    [K in MangoOperator | string]: MangoSelector | MangoValue | MangoValue[];
+    [K in MangoOperator | string]: MangoSelector| MangoSelector[] | MangoValue | MangoValue[];
   }
 
   // http://docs.couchdb.org/en/latest/api/database/find.html#sort-syntax


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
- `MangoSelector` can nest another array of `MangoSelector`
- `DocumentResponseRowMeta` should have an optional member `error`.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
New test cases are not required.
 
## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-nano/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->
NA

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->
NA

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [x] Documentation reflects the changes;
