### PR TITLE
ensure only one HttpAgent is created (not one per request) 

### DIFF
--- a/lib/nano.js
+++ b/lib/nano.js
@@ -20,6 +20,8 @@ const http = require('http')
 const https = require('https')
 const pkg = require('../package.json')
 const AGENT_DEFAULTS = { keepAlive: true, maxSockets: 50, keepAliveMsecs: 30000 }
+const defaultHttpAgent = new http.Agent(AGENT_DEFAULTS)
+const defaultHttpsAgent = new https.Agent(AGENT_DEFAULTS)
 const ChangesReader = require('./changesreader.js')
 
 function isEmpty (val) {
@@ -331,8 +333,8 @@ module.exports = exports = function dbScope (cfg) {
     } else if (opts.dontParse) {
       req.responseType = 'arraybuffer'
     }
-    req.httpAgent = cfg.requestDefaults.agent || new http.Agent(AGENT_DEFAULTS)
-    req.httpsAgent = cfg.requestDefaults.agent || new https.Agent(AGENT_DEFAULTS)
+    req.httpAgent = cfg.requestDefaults.agent || defaultHttpAgent
+    req.httpsAgent = cfg.requestDefaults.agent || defaultHttpsAgent
 
     // actually do the HTTP request
     if (opts.stream) {


### PR DESCRIPTION
- fixes issue #234 

When no overriding HttpAgent was supplied, Nano was creating a new HttpAgent for each request when the expected behaviour was to have one HttpAgent that is reused for every request.