### PR TITLE
fix RequestDefaultOptions TypeScript definitions as per issue #240

### DIFF
--- a/lib/nano.d.ts
+++ b/lib/nano.d.ts
@@ -16,16 +16,21 @@ declare function nano(
 ): nano.ServerScope;
 
 declare namespace nano {
-  interface requestDefaultsOptions {
+  interface RequestDefaultOptionsAuth {
+    username: string,
+    password: string
+  }
+  interface RequestDefaultsOptions {
     timeout: number;
     agent: any;
     headers: object;
+    auth: RequestDefaultOptionsAuth;
   }
 
   interface Configuration {
     url: string;
     cookie?: string;
-    requestDefaults?: requestDefaultsOptions;
+    requestDefaults?: RequestDefaultsOptions;
     log?(id: string, args: any): void;
     parseUrl?: boolean;
     request?(params: any): void;


### PR DESCRIPTION
## Overview

Fix TypeScript definitions for requestDefaults compatibility

## Testing recommendations

No code changes. `tsc lib/nano.d.ts` should work

## GitHub issue number

See issue #240 


## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [x] Documentation reflects the changes;
