### PR TITLE
Save session cookie after calling nano.auth

### DIFF
--- a/lib/nano.js
+++ b/lib/nano.js
@@ -370,7 +370,7 @@ module.exports = exports = function dbScope (cfg) {
         name: username,
         password: password
       }
-    }, function(err, body, headers) {
+    }, function (err, body, headers) {
       if (
         !err &&
          headers['set-cookie'] &&

--- a/lib/nano.js
+++ b/lib/nano.js
@@ -379,7 +379,7 @@ module.exports = exports = function dbScope (cfg) {
         serverScope.config.cookie = headers['set-cookie'][0]
       }
       typeof callback === 'function' && callback(err, body, headers)
-    }
+    })
   }
 
   // http://docs.couchdb.org/en/latest/api/server/authn.html#post--_session

--- a/lib/nano.js
+++ b/lib/nano.js
@@ -370,7 +370,16 @@ module.exports = exports = function dbScope (cfg) {
         name: username,
         password: password
       }
-    }, callback)
+    },function(err, body, headers) {
+      if(
+        !err && 
+         headers['set-cookie'] && 
+         headers['set-cookie'].length
+       ) {
+        serverScope.config.cookie = headers['set-cookie'][0]
+      }
+      typeof callback === 'function' && callback(err, body, headers)
+    }
   }
 
   // http://docs.couchdb.org/en/latest/api/server/authn.html#post--_session

--- a/lib/nano.js
+++ b/lib/nano.js
@@ -363,22 +363,25 @@ module.exports = exports = function dbScope (cfg) {
 
   // http://docs.couchdb.org/en/latest/api/server/authn.html#cookie-authentication
   function auth (username, password, callback) {
-    return relax({
-      method: 'POST',
-      db: '_session',
-      form: {
-        name: username,
-        password: password
-      }
-    }, function (err, body, headers) {
-      if (
-        !err &&
-         headers['set-cookie'] &&
-         headers['set-cookie'].length
-      ) {
-        serverScope.config.cookie = headers['set-cookie'][0]
-      }
-      typeof callback === 'function' && callback(err, body, headers)
+    return new Promise(function (resolve, reject) {
+      relax({
+        method: 'POST',
+        db: '_session',
+        form: {
+          name: username,
+          password: password
+        }
+      }, function (err, body, headers) {
+        if (
+          !err &&
+          headers['set-cookie'] &&
+          headers['set-cookie'].length
+        ) {
+          serverScope.config.cookie = headers['set-cookie'][0]
+        }
+        err ? reject(err) : resolve(body)
+        typeof callback === 'function' && callback(err, body, headers)
+      })
     })
   }
 

--- a/lib/nano.js
+++ b/lib/nano.js
@@ -370,12 +370,12 @@ module.exports = exports = function dbScope (cfg) {
         name: username,
         password: password
       }
-    },function(err, body, headers) {
-      if(
-        !err && 
-         headers['set-cookie'] && 
+    }, function(err, body, headers) {
+      if (
+        !err &&
+         headers['set-cookie'] &&
          headers['set-cookie'].length
-       ) {
+      ) {
         serverScope.config.cookie = headers['set-cookie'][0]
       }
       typeof callback === 'function' && callback(err, body, headers)

--- a/test/nano.auth.test.js
+++ b/test/nano.auth.test.js
@@ -24,12 +24,14 @@ test('should be able to authenticate - POST /_session - nano.auth', async () => 
   const username = 'u'
   const password = 'p'
   const response = { ok: true, name: 'admin', roles: ['_admin', 'admin'] }
+  const cookie = 'AuthSession=YWRtaW46NUU0MTFBMDE6stHsxYnlDy4mYxwZEcnXHn4fm5w; Version=1; Expires=Mon, 10-Feb-2050 09:03:21 GMT; Max-Age=600; Path=/; HttpOnly'
   const scope = nock(COUCH_URL)
     .post('/_session', 'name=u&password=p', { 'content-type': 'application/x-www-form-urlencoded; charset=utf-8' })
-    .reply(200, response, { 'Set-Cookie': 'AuthSession=YWRtaW46NUU0MTFBMDE6stHsxYnlDy4mYxwZEcnXHn4fm5w; Version=1; Expires=Mon, 10-Feb-2050 09:03:21 GMT; Max-Age=600; Path=/; HttpOnly' })
+    .reply(200, response, { 'Set-Cookie': cookie })
 
   // test POST /_session
   const p = await nano.auth(username, password)
   expect(p).toStrictEqual(response)
+  expect(nano.config.cookie).toStrictEqual(cookie)
   expect(scope.isDone()).toBe(true)
 })


### PR DESCRIPTION
## Overview

Calling nano.auth does not have any effect, next request results in 401 unauthenticated errors.

## Testing recommendations

1. Create new nano without any auth
2. Call nano.auth with correct username and password
3. Try to access or update protected document

## GitHub issue number

No previous issues.

## Related Pull Requests

No related pull requests.

## Checklist

- [X ] Code is written and works correctly;
- [X] Changes are covered by tests;
- [X] Documentation reflects the changes;
