### PR TITLE
Fix invalid parameters error stack trace

### DIFF
--- a/lib/nano.js
+++ b/lib/nano.js
@@ -14,7 +14,6 @@ const { URL } = require('url')
 const assert = require('assert')
 const querystring = require('qs')
 const axios = require('axios').default
-const INVALID_PARAMETERS_ERROR = new Error('Invalid parameters')
 const stream = require('stream')
 const http = require('http')
 const https = require('https')
@@ -47,7 +46,7 @@ function missing (...params) {
 }
 
 // calls the supplied callback or if not supplied, returns a rejected promise
-function callbackOrRejectError (callback, error = INVALID_PARAMETERS_ERROR) {
+function callbackOrRejectError (callback, error = new Error('Invalid parameters')) {
   if (callback) {
     return callback(error, null)
   } else {


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

"Invalid parameters" error types were instantiated once at the module's global scope, which causes the stack trace for the error to be static and not helpful to the user. By moving the error instantiation to the scope where it's thrown, the stack trace is useful to the user.

## Testing recommendations

Test by providing some invalid parameters any of the database object methods. Expect a stack trace containing the method invocation line.

## GitHub issue number

Fixes #243 

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [x] Documentation reflects the changes;
