### PR TITLE
Fix cookie/session support in Nano 9

### DIFF
--- a/lib/nano.js
+++ b/lib/nano.js
@@ -370,7 +370,7 @@ module.exports = exports = function dbScope (cfg) {
         name: username,
         password: password
       }
-    }, function(err, body, headers) {
+    }, function (err, body, headers) {
       if (
         !err &&
          headers['set-cookie'] &&

--- a/lib/nano.js
+++ b/lib/nano.js
@@ -379,7 +379,7 @@ module.exports = exports = function dbScope (cfg) {
         serverScope.config.cookie = headers['set-cookie'][0]
       }
       typeof callback === 'function' && callback(err, body, headers)
-    }
+    })
   }
 
   // http://docs.couchdb.org/en/latest/api/server/authn.html#post--_session

--- a/lib/nano.js
+++ b/lib/nano.js
@@ -370,7 +370,16 @@ module.exports = exports = function dbScope (cfg) {
         name: username,
         password: password
       }
-    }, callback)
+    },function(err, body, headers) {
+      if(
+        !err && 
+         headers['set-cookie'] && 
+         headers['set-cookie'].length
+       ) {
+        serverScope.config.cookie = headers['set-cookie'][0]
+      }
+      typeof callback === 'function' && callback(err, body, headers)
+    }
   }
 
   // http://docs.couchdb.org/en/latest/api/server/authn.html#post--_session

--- a/lib/nano.js
+++ b/lib/nano.js
@@ -14,6 +14,10 @@ const { URL } = require('url')
 const assert = require('assert')
 const querystring = require('qs')
 const axios = require('axios').default
+const axiosCookieJarSupport = require('axios-cookiejar-support').default
+const tough = require('tough-cookie')
+axiosCookieJarSupport(axios)
+const cookieJar = new tough.CookieJar()
 const INVALID_PARAMETERS_ERROR = new Error('Invalid parameters')
 const stream = require('stream')
 const http = require('http')
@@ -224,7 +228,8 @@ module.exports = exports = function dbScope (cfg) {
     const isJar = opts.jar || cfg.jar
 
     if (isJar) {
-      req.jar = isJar
+      req.jar = cookieJar
+      req.withCredentials = true
     }
 
     // http://wiki.apache.org/couchdb/HTTP_database_API#Naming_and_Addressing
@@ -313,6 +318,7 @@ module.exports = exports = function dbScope (cfg) {
     req.qsStringifyOptions = { arrayFormat: 'repeat' }
 
     log(req)
+    cfg.cookies = cookieJar.getCookiesSync(cfg.url)
 
     // This where the HTTP request is made.
     // Nano used to use the now-deprecated "request" library but now we're going to
@@ -363,26 +369,14 @@ module.exports = exports = function dbScope (cfg) {
 
   // http://docs.couchdb.org/en/latest/api/server/authn.html#cookie-authentication
   function auth (username, password, callback) {
-    return new Promise(function (resolve, reject) {
-      relax({
-        method: 'POST',
-        db: '_session',
-        form: {
-          name: username,
-          password: password
-        }
-      }, function (err, body, headers) {
-        if (
-          !err &&
-          headers['set-cookie'] &&
-          headers['set-cookie'].length
-        ) {
-          serverScope.config.cookie = headers['set-cookie'][0]
-        }
-        err ? reject(err) : resolve(body)
-        typeof callback === 'function' && callback(err, body, headers)
-      })
-    })
+    return relax({
+      method: 'POST',
+      db: '_session',
+      form: {
+        name: username,
+        password: password
+      }
+    }, callback)
   }
 
   // http://docs.couchdb.org/en/latest/api/server/authn.html#post--_session

--- a/lib/nano.js
+++ b/lib/nano.js
@@ -363,22 +363,25 @@ module.exports = exports = function dbScope (cfg) {
 
   // http://docs.couchdb.org/en/latest/api/server/authn.html#cookie-authentication
   function auth (username, password, callback) {
-    return relax({
-      method: 'POST',
-      db: '_session',
-      form: {
-        name: username,
-        password: password
-      }
-    }, function (err, body, headers) {
-      if (
-        !err &&
-         headers['set-cookie'] &&
-         headers['set-cookie'].length
-      ) {
-        serverScope.config.cookie = headers['set-cookie'][0]
-      }
-      typeof callback === 'function' && callback(err, body, headers)
+    return new Promise(function (resolve, reject) {
+      relax({
+        method: 'POST',
+        db: '_session',
+        form: {
+          name: username,
+          password: password
+        }
+      }, function (err, body, headers) {
+        if (
+          !err &&
+          headers['set-cookie'] &&
+          headers['set-cookie'].length
+        ) {
+          serverScope.config.cookie = headers['set-cookie'][0]
+        }
+        err ? reject(err) : resolve(body)
+        typeof callback === 'function' && callback(err, body, headers)
+      })
     })
   }
 

--- a/lib/nano.js
+++ b/lib/nano.js
@@ -370,12 +370,12 @@ module.exports = exports = function dbScope (cfg) {
         name: username,
         password: password
       }
-    },function(err, body, headers) {
-      if(
-        !err && 
-         headers['set-cookie'] && 
+    }, function(err, body, headers) {
+      if (
+        !err &&
+         headers['set-cookie'] &&
          headers['set-cookie'].length
-       ) {
+      ) {
         serverScope.config.cookie = headers['set-cookie'][0]
       }
       typeof callback === 'function' && callback(err, body, headers)

--- a/package-lock.json
+++ b/package-lock.json
@@ -999,6 +999,22 @@
         "follow-redirects": "^1.10.0"
       }
     },
+    "axios-cookiejar-support": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/axios-cookiejar-support/-/axios-cookiejar-support-1.0.1.tgz",
+      "integrity": "sha512-IZJxnAJ99XxiLqNeMOqrPbfR7fRyIfaoSLdPUf4AMQEGkH8URs0ghJK/xtqBsD+KsSr3pKl4DEQjCn834pHMig==",
+      "requires": {
+        "is-redirect": "^1.0.0",
+        "pify": "^5.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-5.0.0.tgz",
+          "integrity": "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA=="
+        }
+      }
+    },
     "babel-jest": {
       "version": "26.6.1",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.6.1.tgz",
@@ -1355,7 +1371,7 @@
     },
     "contains-path": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/wcp-wdp-npm-virtual/contains-path/-/contains-path-0.1.0.tgz",
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true
     },
@@ -1650,7 +1666,7 @@
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/wcp-wdp-npm-virtual/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
@@ -1842,7 +1858,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/wcp-wdp-npm-virtual/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
@@ -1888,7 +1904,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/wcp-wdp-npm-virtual/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
@@ -1975,7 +1991,7 @@
         },
         "doctrine": {
           "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/wcp-wdp-npm-virtual/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
@@ -2004,7 +2020,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/wcp-wdp-npm-virtual/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
@@ -2540,7 +2556,7 @@
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/wcp-wdp-npm-virtual/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
@@ -2559,7 +2575,7 @@
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/wcp-wdp-npm-virtual/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
@@ -2836,7 +2852,7 @@
     },
     "imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/wcp-wdp-npm-virtual/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
@@ -2895,7 +2911,7 @@
     },
     "is-arrayish": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/wcp-wdp-npm-virtual/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
@@ -3041,6 +3057,11 @@
       "integrity": "sha1-DFLlS8yjkbssSUsh6GJtczbG45c=",
       "dev": true
     },
+    "is-redirect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
+    },
     "is-regex": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
@@ -3095,7 +3116,7 @@
     },
     "isarray": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/wcp-wdp-npm-virtual/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
@@ -3755,6 +3776,19 @@
         "whatwg-url": "^8.0.0",
         "ws": "^7.2.3",
         "xml-name-validator": "^3.0.0"
+      },
+      "dependencies": {
+        "tough-cookie": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
+          "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
+          "dev": true,
+          "requires": {
+            "ip-regex": "^2.1.0",
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+          }
+        }
       }
     },
     "jsesc": {
@@ -3789,7 +3823,7 @@
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/wcp-wdp-npm-virtual/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
@@ -3866,7 +3900,7 @@
     },
     "load-json-file": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/wcp-wdp-npm-virtual/load-json-file/-/load-json-file-2.0.0.tgz",
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
       "requires": {
@@ -4079,7 +4113,7 @@
     },
     "natural-compare": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/wcp-wdp-npm-virtual/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
@@ -4188,7 +4222,7 @@
     },
     "object-assign": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/wcp-wdp-npm-virtual/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
@@ -4415,7 +4449,7 @@
     },
     "path-key": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/wcp-wdp-npm-virtual/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true
     },
@@ -4427,7 +4461,7 @@
     },
     "path-type": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/wcp-wdp-npm-virtual/path-type/-/path-type-2.0.0.tgz",
       "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
       "dev": true,
       "requires": {
@@ -4448,7 +4482,7 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/wcp-wdp-npm-virtual/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
@@ -4514,7 +4548,7 @@
         },
         "parse-json": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/wcp-wdp-npm-virtual/parse-json/-/parse-json-4.0.0.tgz",
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
@@ -4625,8 +4659,7 @@
     "psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
-      "dev": true
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
     },
     "pump": {
       "version": "3.0.0",
@@ -4641,8 +4674,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
       "version": "6.9.4",
@@ -5086,7 +5118,7 @@
     },
     "shebang-command": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/wcp-wdp-npm-virtual/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
@@ -5095,7 +5127,7 @@
     },
     "shebang-regex": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/wcp-wdp-npm-virtual/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
@@ -5730,7 +5762,7 @@
     },
     "text-table": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/wcp-wdp-npm-virtual/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
@@ -5794,14 +5826,13 @@
       }
     },
     "tough-cookie": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
-      "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
-      "dev": true,
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
+      "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
       "requires": {
-        "ip-regex": "^2.1.0",
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.1.2"
       }
     },
     "tr46": {
@@ -5904,6 +5935,11 @@
         "is-extendable": "^0.1.1",
         "set-value": "^2.0.1"
       }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "unset-value": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
   ],
   "dependencies": {
     "axios": "^0.21.0",
-    "qs": "^6.9.4"
+    "axios-cookiejar-support": "^1.0.1",
+    "qs": "^6.9.4",
+    "tough-cookie": "^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^14.14.6",

--- a/test/nano.auth.test.js
+++ b/test/nano.auth.test.js
@@ -24,12 +24,14 @@ test('should be able to authenticate - POST /_session - nano.auth', async () => 
   const username = 'u'
   const password = 'p'
   const response = { ok: true, name: 'admin', roles: ['_admin', 'admin'] }
+  const cookie = 'AuthSession=YWRtaW46NUU0MTFBMDE6stHsxYnlDy4mYxwZEcnXHn4fm5w; Version=1; Expires=Mon, 10-Feb-2050 09:03:21 GMT; Max-Age=600; Path=/; HttpOnly'
   const scope = nock(COUCH_URL)
     .post('/_session', 'name=u&password=p', { 'content-type': 'application/x-www-form-urlencoded; charset=utf-8' })
-    .reply(200, response, { 'Set-Cookie': 'AuthSession=YWRtaW46NUU0MTFBMDE6stHsxYnlDy4mYxwZEcnXHn4fm5w; Version=1; Expires=Mon, 10-Feb-2050 09:03:21 GMT; Max-Age=600; Path=/; HttpOnly' })
+    .reply(200, response, { 'Set-Cookie': cookie })
 
   // test POST /_session
   const p = await nano.auth(username, password)
   expect(p).toStrictEqual(response)
+  expect(nano.config.cookie).toStrictEqual(cookie)
   expect(scope.isDone()).toBe(true)
 })


### PR DESCRIPTION
## Overview

In Nano 8, supplying `{jar: true}` when starting up Nano forced the `request` library to parse, store and replay cookies which made the `auth` endpoint work correctly. In Nano 9, the axios library has no built-in cookie support so this PR fixes that by adding a couple of dependencies and using them when the `{jar: true}` parameter is set.

Thanks to @robman87 for pointing this out. [His PR](https://github.com/apache/couchdb-nano/pull/242) was simpler but I opted for a "proper" cookie parser because folks use CouchDB in a lot of different ways and they may want their library/client to correctly interpret/parse/invalidate other cookies correctly too - not just the CouchDB authentication session cookie.
## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [x] Documentation reflects the changes;
