### PR TITLE
Add RequestError typescript definition

### DIFF
--- a/lib/nano.d.ts
+++ b/lib/nano.d.ts
@@ -36,7 +36,31 @@ declare namespace nano {
     request?(params: any): void;
   }
 
-  type Callback<R> = (error: any, response: R, headers?: any) => void;
+  type Callback<R> = (error: RequestError | null, response: R, headers?: any) => void;
+
+  // An error triggered by nano
+  interface RequestError extends Error {
+    // An error code.
+    error?: string; // 'not_found', 'file_exists'
+    // Human readable reason for the error.
+    reason?: string; // 'missing', 'The database could not be created, the file already exists.';
+    // Was the problem at the socket or couch level
+    scope?: 'couch'  | 'socket';
+    // Status code returned by the server
+    statusCode?: number; // 404;
+    // Request sent to Couch
+    request?: {
+      method?: 'GET' | 'POST' | 'PUT' | 'DELETE';
+      headers?: { [key: string]: string | number };
+      uri?: string; // 'http://couchhost:5984/db/tsp2',
+      qs?: any; // { revs_info: true }
+    };
+    // Response headers
+    headers?: { [key: string]: string | number };
+    // Error identifier
+    errid?: 'non_200' | 'request'; // string; // 'non_200'
+    description?: string;
+  }
 
   interface ServerScope {
     readonly config: ServerConfig;


### PR DESCRIPTION
## Overview

Errors triggered by nano are extended with additional fields, this commits adds the typescript definition for them.

The name "RequestError" was chosen because it seems like it all nano errors are triggered by a request (a 'socket' or a 'couch' error).

I considered "NanoError", but the full type `nano.NanoError` doesn't sound better than `nano.RequestError` and no other interface have been prefixed with "Nano".

I've extracted the error fields from `nano.js`.

## Testing recommendations

There's no typescript tests so far, I included this change in my typescript project.

This change can affect users if they uses nano with callbacks incorrectly, their project could fail building.

Errors are simple to fix. For example, on my project there was an instance where I used `error.status` instead of `error.statusCode`. Another issue is that I passed a callback that expected `Error | undefined` for the error field while nano sends `Error | null`.

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
