### PR TITLE
scrub all requests and auth header, fix changeReader stall - fixes #255, #257

### DIFF
--- a/lib/changesreader.js
+++ b/lib/changesreader.js
@@ -210,7 +210,7 @@ class ChangesReader {
               self.continue = false
             } else {
               // don't immediately retry on error - exponential back-off
-              delay = delay ? Math.max(60000, delay * 2) : 5000
+              delay = delay ? Math.min(60000, delay * 2) : 5000 // up to and no more than one minute
             }
 
             self.ee.emit(EVENT_ERROR, err)

--- a/lib/nano.js
+++ b/lib/nano.js
@@ -101,6 +101,22 @@ module.exports = exports = function dbScope (cfg) {
     }
     return str
   }
+
+  function scrubRequest (req, cloned) {
+    // scrub credentials
+    req.url = scrubURL(req.url)
+    if (req.headers.cookie) {
+      req.headers.cookie = 'XXXXXXX'
+    }
+    if (req.auth) {
+      if (!cloned) {
+        req.auth = JSON.parse(JSON.stringify(req.auth)) // clone just auth if not already cloned
+      }
+      req.auth.username = SCRUBBED_STR
+      req.auth.password = SCRUBBED_STR
+    }
+  }
+
   const responseHandler = function (response, req, opts, resolve, reject, callback) {
     const statusCode = response.status || (response.response && response.response.status) || 500
     if (response.isAxiosError && response.response) {
@@ -163,11 +179,8 @@ module.exports = exports = function dbScope (cfg) {
     delete body.stack
 
     // scrub credentials
-    req.url = scrubURL(req.url)
+    scrubRequest(req)
     responseHeaders.uri = scrubURL(responseHeaders.uri)
-    if (req.headers.cookie) {
-      req.headers.cookie = 'XXXXXXX'
-    }
 
     log({ err: 'couch', body: body, headers: responseHeaders })
 
@@ -200,6 +213,8 @@ module.exports = exports = function dbScope (cfg) {
       response = response.response
     }
     const message = response.statusText
+
+    scrubRequest(req)
 
     const responseHeaders = Object.assign({
       uri: req.url,
@@ -368,11 +383,7 @@ module.exports = exports = function dbScope (cfg) {
 
     // scrub and log
     const scrubbedReq = JSON.parse(JSON.stringify(req))
-    scrubbedReq.url = scrubURL(scrubbedReq.url)
-    if (scrubbedReq.auth) {
-      scrubbedReq.auth.username = SCRUBBED_STR
-      scrubbedReq.auth.password = SCRUBBED_STR
-    }
+    scrubRequest(scrubbedReq, true)
     log(scrubbedReq)
 
     // add http agents

--- a/lib/nano.js
+++ b/lib/nano.js
@@ -127,7 +127,7 @@ module.exports = exports = function dbScope (cfg) {
 
     // let parsed
     const responseHeaders = Object.assign({
-      uri: req.url,
+      uri: scrubURL(req.url),
       statusCode: statusCode
     }, response.headers)
     if (!response.status) {
@@ -180,7 +180,6 @@ module.exports = exports = function dbScope (cfg) {
 
     // scrub credentials
     scrubRequest(req)
-    responseHeaders.uri = scrubURL(responseHeaders.uri)
 
     log({ err: 'couch', body: body, headers: responseHeaders })
 


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
This solves #255 by centrally scrubbing all requests auth header from logging and response stream and response error handling. This also adds scrubbing to response stream error handling.

This pull also solves #257 by replacing Math.max with Math.min so that back-off will max out at 60 seconds (1 minute) instead of escalating to really large numbers when connectivity is unavailable or timeout errors occur in succesion.

## Testing recommendations

This provides no functional or end behaviour changes. 
<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## GitHub issue number

Fixes #255 
Also Fixes #257 

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-nano/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Checklist

- [x] Code is written and works correctly;
- [x] All existing tests pass;
