### PR TITLE
Add type definitions for changesReader methods

### DIFF
--- a/lib/nano.d.ts
+++ b/lib/nano.d.ts
@@ -271,6 +271,10 @@ declare namespace nano {
     spool(opts: ChangesReaderOptions): EventEmitter;
     /** stop consuming the changes feed */
     stop(): void;
+    /** pause consuming the changes feed */
+    pause(): void;
+    /** resume consuming the changes feed */
+    resume(): void;
   }
 
   /** Documents scope */


### PR DESCRIPTION
## Overview

Adds missing Typescript definitions for `changesReader` methods that are implemented and referenced in the documentation. These are `pause()` and `resume()` which currently cause type check issues if using Typescript with `nano`.

## Testing recommendations

Implement a `wait: true` changes reader with `nano` in a `Typescript` module. Attempting to use `resume()` after processing a change causes a type error when running a type check:

`tsc -p .`

