### PR TITLE
changesreader /added fields & body support

### DIFF
--- a/README.md
+++ b/README.md
@@ -666,7 +666,10 @@ You may supply a number of options when you start to listen to the changes feed:
 | includeDocs | Whether to include document bodies or not | false | e.g. true |
 | wait | For `get`/`start` mode, automatically pause the changes reader after each request. When the the user calls `resume()`, the changes reader will resume.  | false | e.g. true |
 | fastChanges | Adds a seq_interval parameter to fetch changes more quickly | false           | true                             |   |
-| selector | Filters the changes feed with the supplied Mango selector | {"name":"fred}           | null                             |   |
+| selector | Filters the changes feed with the supplied Mango selector |  null          | { "name": "fred" } |   |
+| fields | Filters the changes feed with the supplied fields list | null           | [ 'id', 'seq' ]                             |   |
+| qs | Additional query string parameters | null           | { "filter": "_selector" }                            |   |
+| body | Additional body parameters | null           | { "fields": [ "id", "seq" ] }                            |   |
 | timeout | The number of milliseconds a changes feed request waits for data| 60000         | 10000     
 
 The events it emits are as follows:s

--- a/lib/changesreader.js
+++ b/lib/changesreader.js
@@ -101,7 +101,9 @@ class ChangesReader {
     this.stopOnEmptyChanges = false // whether to stop polling if we get an empty set of changes back
     this.continue = true // whether to poll again
     this.qs = {} // extra querystring parameters
+    this.body = {} // extra body parameters
     this.selector = null
+    this.fields = null
     this.paused = false
   }
 
@@ -165,11 +167,17 @@ class ChangesReader {
           if (self.fastChanges) {
             req.qs.seq_interval = self.batchSize
           }
-          if (self.selector) {
+          if (self.selector || self.fields) {
             req.qs.filter = '_selector'
-            req.body.selector = self.selector
+            if (self.selector) {
+              req.body.selector = self.selector
+            }
+            if (self.fields) {
+              req.body.fields = self.fields
+            }
           }
           Object.assign(req.qs, opts.qs)
+          Object.assign(req.body, opts.body)
 
           // make HTTP request to get up to batchSize changes from the feed
           try {

--- a/lib/nano.d.ts
+++ b/lib/nano.d.ts
@@ -257,18 +257,22 @@ declare namespace nano {
     wait?: boolean;
     /** additional query string parameters */
     qs?: object;
+    /** additional body parameters */
+    body?: object;
     /** a MangoSelector defining the slice of the changes feed to return */
     selector?: MangoSelector;
+    /** a MangoSelector defining changes feed fields to return */
+    fields?: string[];
   }
 
   /** ChangesReader functions */
   interface ChangesReaderScope {
     /** fetch changes forever */
-    start(opts: ChangesReaderOptions): EventEmitter;
+    start(opts?: ChangesReaderOptions): EventEmitter;
     /** fetch changes and stop when an empty batch is received */
-    get(opts: ChangesReaderOptions): EventEmitter;
+    get(opts?: ChangesReaderOptions): EventEmitter;
     /** spool the change in one long feed, instead of batches */
-    spool(opts: ChangesReaderOptions): EventEmitter;
+    spool(opts?: ChangesReaderOptions): EventEmitter;
     /** stop consuming the changes feed */
     stop(): void;
     /** pause consuming the changes feed */


### PR DESCRIPTION
## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

This PR is addressing issue #263

In simple words, it is adding support for `fields` and `body` params for changesreader.

## Testing recommendations

You can run this code against any running CouchDB database e.g. https://registry.npmjs.org/

```
db.changesReader
  .start({ fields })
  .on('changes', console.log);
```

## GitHub issue number

#263 

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [x] Documentation reflects the changes;
