### PR TITLE
fix: circular ref error when passing agent

### DIFF
--- a/lib/nano.js
+++ b/lib/nano.js
@@ -381,6 +381,7 @@ module.exports = exports = function dbScope (cfg) {
     }
 
     // scrub and log
+    delete req.agent // Agent contains circular refs that does not works well with JSON.stringify
     const scrubbedReq = JSON.parse(JSON.stringify(req))
     scrubRequest(scrubbedReq, true)
     log(scrubbedReq)


### PR DESCRIPTION
## Overview

When passing an `agent` to nano, the process of scrubbing and logging breaks because of circular refs.
![Screenshot 2021-07-15 at 12 56 08](https://user-images.githubusercontent.com/1637651/125777103-6d84e5b2-4f53-476c-9c2c-54d744b53eb4.png)

I have fixed by removing the pointer ref, but an other solution would be to use a deref like `flatted`
The agent should still in the original object `cfg.requestDefaults` (for the line 380)

## Testing recommendations

```ts
import https from 'https';
import nano from 'nano';

const httpsAgent = new https.Agent(options);
const registry = nano({
  url: <YOUR_URL>,
  requestDefaults: {
    agent: httpsAgent,
    timeout: 15000,
    headers: {
      'user-agent': 'fdfd',
      'Accept-Encoding': 'deflate, gzip',
      'content-type': 'application/json',
      accept: 'application/json',
    },
  },
});
```

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
