### PR TITLE
Document the options to `db.create()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,12 +296,12 @@ db.insert(p).then((response) => {
 
 ## Database functions
 
-### nano.db.create(name, [callback])
+### nano.db.create(name, [opts], [callback])
 
-Creates a CouchDB database with the given `name`:
+Creates a CouchDB database with the given `name`, with options `opts`.
 
 ```js
-await nano.db.create('alice')
+await nano.db.create('alice', { n: 3 })
 ```
 
 ### nano.db.get(name, [callback])


### PR DESCRIPTION
In the source code, the `createDb()` function accepts an options object
but this is not documented. The `PUT /{db}` endpoint [1] does have some
query string options and `nano` users should be able to make use of
them.

[1]: https://docs.couchdb.org/en/stable/api/database/common.html#put--db