### PR TITLE
Type update_seq as optional in DocumentViewResponse

### DIFF
--- a/lib/nano.d.ts
+++ b/lib/nano.d.ts
@@ -1663,7 +1663,7 @@ declare namespace nano {
     total_rows: number;
 
     /** Current update sequence for the database */
-    update_seq: any;
+    update_seq?: any;
   }
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
When calling `db.view`, a value for update_seq is only returned if requested in the params with `update_seq: true`. Therefore, the type for the response in `DocumentViewResponse` should have this as optional


## Testing recommendations
Call any view with `update_seq: false` in the params, notice how `update_seq` is not in the return value


## Checklist

- [x] Code is written and works correctly;
- (N/A) Changes are covered by tests;
- (N/A) Documentation reflects the changes;
