### PR TITLE
Add docName to TypeScript type definition

### DIFF
--- a/lib/nano.d.ts
+++ b/lib/nano.d.ts
@@ -1109,6 +1109,9 @@ declare namespace nano {
    * @see POST docs: {@link http://docs.couchdb.org/en/latest/api/database/common.html#post--db}
    * @see PUT docs: {@link http://docs.couchdb.org/en/latest/api/document/common.html#put--db-docid} */
   interface DocumentInsertParams {
+    /** Document ID */
+    docName?: string;
+    
     /** Document’s revision if updating an existing document. Alternative to If-Match header or document key. */
     rev?: string;
 


### PR DESCRIPTION
This parameter noted in [the docs](https://github.com/apache/couchdb-nano/tree/2d4bd719e4f08915ed9c0ef7953e901391ce4239#dbinsertdoc-params-callback).

Cheers!

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [x] Documentation reflects the changes;
