### PR TITLE
Properly escape partition ID's

### DIFF
--- a/lib/nano.js
+++ b/lib/nano.js
@@ -1036,7 +1036,7 @@ module.exports = exports = function dbScope (cfg) {
 
       return relax({
         db: dbName,
-        path: '_partition/' + partitionKey
+        path: '_partition/' + encodeURIComponent(partitionKey)
       }, callback)
     }
 
@@ -1047,7 +1047,7 @@ module.exports = exports = function dbScope (cfg) {
       }
       return relax({
         db: dbName,
-        path: '_partition/' + partitionKey + '/_all_docs',
+        path: '_partition/' + encodeURIComponent(partitionKey) + '/_all_docs',
         qs: opts
       }, callback)
     }
@@ -1055,7 +1055,7 @@ module.exports = exports = function dbScope (cfg) {
     function partitionedListAsStream (partitionKey, qs) {
       return relax({
         db: dbName,
-        path: '_partition/' + partitionKey + '/_all_docs',
+        path: '_partition/' + encodeURIComponent(partitionKey) + '/_all_docs',
         qs: qs,
         stream: true
       })
@@ -1068,7 +1068,7 @@ module.exports = exports = function dbScope (cfg) {
 
       return relax({
         db: dbName,
-        path: '_partition/' + partition + '/_find',
+        path: '_partition/' + encodeURIComponent(partition) + '/_find',
         method: 'POST',
         body: query
       }, callback)
@@ -1077,7 +1077,7 @@ module.exports = exports = function dbScope (cfg) {
     function partitionedFindAsStream (partition, query) {
       return relax({
         db: dbName,
-        path: '_partition/' + partition + '/_find',
+        path: '_partition/' + encodeURIComponent(partition) + '/_find',
         method: 'POST',
         body: query,
         stream: true
@@ -1090,7 +1090,7 @@ module.exports = exports = function dbScope (cfg) {
       }
       return relax({
         db: dbName,
-        path: '_partition/' + partition + '/_design/' + ddoc + '/_search/' + searchName,
+        path: '_partition/' + encodeURIComponent(partition) + '/_design/' + ddoc + '/_search/' + searchName,
         qs: opts
       }, callback)
     }
@@ -1098,7 +1098,7 @@ module.exports = exports = function dbScope (cfg) {
     function partitionedSearchAsStream (partition, ddoc, searchName, opts) {
       return relax({
         db: dbName,
-        path: '_partition/' + partition + '/_design/' + ddoc + '/_search/' + searchName,
+        path: '_partition/' + encodeURIComponent(partition) + '/_design/' + ddoc + '/_search/' + searchName,
         qs: opts,
         stream: true
       })
@@ -1110,7 +1110,7 @@ module.exports = exports = function dbScope (cfg) {
       }
       return relax({
         db: dbName,
-        path: '_partition/' + partition + '/_design/' + ddoc + '/_view/' + viewName,
+        path: '_partition/' + encodeURIComponent(partition) + '/_design/' + ddoc + '/_view/' + viewName,
         qs: opts
       }, callback)
     }
@@ -1118,7 +1118,7 @@ module.exports = exports = function dbScope (cfg) {
     function partitionedViewAsStream (partition, ddoc, viewName, opts) {
       return relax({
         db: dbName,
-        path: '_partition/' + partition + '/_design/' + ddoc + '/_view/' + viewName,
+        path: '_partition/' + encodeURIComponent(partition) + '/_design/' + ddoc + '/_view/' + viewName,
         qs: opts,
         stream: true
       })

--- a/test/partition.list.test.js
+++ b/test/partition.list.test.js
@@ -121,6 +121,23 @@ test('should be able to list partition docs (callback) - GET /db/_partition/_all
   })
 })
 
+test('should escape unusual characters - GET /db/_partition/a+b/_all_docs - db.partitionedList', async () => {
+  // mocks
+  const scope = nock(COUCH_URL)
+    .get('/db/_partition/a%2Bb/_all_docs')
+    .reply(200, response)
+
+  // test GET /db/_partition/_all_docs
+  return new Promise((resolve, reject) => {
+    db.partitionedList('a+b', (err, data) => {
+      expect(err).toBeNull()
+      expect(data).toStrictEqual(response)
+      expect(scope.isDone()).toBe(true)
+      resolve()
+    })
+  })
+})
+
 test('should handle missing database - GET /db/_partition/_all_docs - db.partitionedList', async () => {
   // mocks
   const scope = nock(COUCH_URL)


### PR DESCRIPTION
## Overview

This fixes issue #283, by running partition ID's through `encodeUriComponent`. This is consistent with the way Nano handles other things that may contain special characters, such as database ID's or document ID's.

However, this is a breaking change, for reasons described in that bug report.

## Testing recommendations

Try creating a partitioned database with partition ID's like `a+b` in Fauxton. If you invoke `db.partitionedList('a+b')` before this PR, you will get no results, but after this PR, it will work.

## GitHub issue number

#283

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;

I can do steps 2 & 3 if there is interest in accepting this proposed change.