### PR TITLE
Add include_docs to DocumentFetchParams typescript definition

### DIFF
--- a/lib/nano.d.ts
+++ b/lib/nano.d.ts
@@ -1350,6 +1350,7 @@ declare namespace nano {
     descending?: boolean;
     end_key?: string;
     end_key_doc_id?: string;
+    include_docs?: boolean;
     inclusive_end?: boolean;
     key?: string;
     keys?: string | string[]; 


### PR DESCRIPTION
Add include_docs to DocumentFetchParams typescript definition, as mentioned in https://github.com/apache/couchdb-nano/tree/2d4bd719e4f08915ed9c0ef7953e901391ce4239#dbpartitionedlistpartitionkey-params-callback


## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [x] Documentation reflects the changes;
