### PR TITLE
removes axios-cookiejar-support. See issue#295

### DIFF
--- a/lib/nano.js
+++ b/lib/nano.js
@@ -10,22 +10,19 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+const { HttpsCookieAgent, HttpCookieAgent } = require('http-cookie-agent')
 const { URL } = require('url')
 const assert = require('assert')
 const querystring = require('qs')
-const axios = require('axios').default
-const axiosCookieJarSupport = require('axios-cookiejar-support').default
-const tough = require('tough-cookie')
-axiosCookieJarSupport(axios)
-const cookieJar = new tough.CookieJar()
+const axios = require('axios')
+const { CookieJar } = require('tough-cookie')
+const cookieJar = new CookieJar()
 const stream = require('stream')
-const http = require('http')
-const https = require('https')
 const pkg = require('../package.json')
-const AGENT_DEFAULTS = { keepAlive: true, maxSockets: 50, keepAliveMsecs: 30000 }
+const AGENT_DEFAULTS = { jar: cookieJar, keepAlive: true, maxSockets: 50, keepAliveMsecs: 30000 }
 const SCRUBBED_STR = 'XXXXXX'
-const defaultHttpAgent = new http.Agent(AGENT_DEFAULTS)
-const defaultHttpsAgent = new https.Agent(AGENT_DEFAULTS)
+const defaultHttpAgent = new HttpCookieAgent(AGENT_DEFAULTS)
+const defaultHttpsAgent = new HttpsCookieAgent(AGENT_DEFAULTS)
 const ChangesReader = require('./changesreader.js')
 const MultiPartFactory = require('./multipart.js')
 
@@ -400,12 +397,18 @@ module.exports = exports = function dbScope (cfg) {
     // add http agents
     req.httpAgent = cfg.requestDefaults.agent || defaultHttpAgent
     req.httpsAgent = cfg.requestDefaults.agent || defaultHttpsAgent
+    req.httpAgent.jar = req.httpAgent.jar ? req.httpAgent.jar : cookieJar
+    req.httpsAgent.jar = req.httpsAgent.jar ? req.httpsAgent.jar : cookieJar
+    const ax = axios.create({
+      httpAgent: req.httpAgent,
+      httpsAgent: req.httpsAgent
+    })
 
     // actually do the HTTP request
     if (opts.stream) {
       // return the Request object for streaming
       const outStream = new stream.PassThrough()
-      axios(req)
+      ax(req)
         .then((response) => {
           response.data.pipe(outStream)
         }).catch(e => {
@@ -414,14 +417,14 @@ module.exports = exports = function dbScope (cfg) {
       return outStream
     } else {
       if (typeof callback === 'function') {
-        axios(req).then((response) => {
+        ax(req).then((response) => {
           responseHandler(response, req, opts, null, null, callback)
         }).catch((e) => {
           responseHandler(e, req, opts, null, null, callback)
         })
       } else {
         return new Promise((resolve, reject) => {
-          axios(req).then((response) => {
+          ax(req).then((response) => {
             responseHandler(response, req, opts, resolve, reject)
           }).catch((e) => {
             responseHandler(e, req, opts, resolve, reject)

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@types/tough-cookie": "^4.0.0",
         "axios": "^0.26.1",
-        "axios-cookiejar-support": "^1.0.1",
+        "http-cookie-agent": "^1.0.5",
         "qs": "^6.10.3",
         "tough-cookie": "^4.0.0"
       },
@@ -1110,7 +1110,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
       "dependencies": {
         "debug": "4"
       },
@@ -1291,34 +1290,6 @@
       "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
       "dependencies": {
         "follow-redirects": "^1.14.8"
-      }
-    },
-    "node_modules/axios-cookiejar-support": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/axios-cookiejar-support/-/axios-cookiejar-support-1.0.1.tgz",
-      "integrity": "sha512-IZJxnAJ99XxiLqNeMOqrPbfR7fRyIfaoSLdPUf4AMQEGkH8URs0ghJK/xtqBsD+KsSr3pKl4DEQjCn834pHMig==",
-      "dependencies": {
-        "is-redirect": "^1.0.0",
-        "pify": "^5.0.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "peerDependencies": {
-        "@types/tough-cookie": ">=2.3.3",
-        "axios": ">=0.16.2",
-        "tough-cookie": ">=2.3.3"
-      }
-    },
-    "node_modules/axios-cookiejar-support/node_modules/pify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-5.0.0.tgz",
-      "integrity": "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/babel-jest": {
@@ -1702,7 +1673,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
       "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -3038,6 +3008,20 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
+    "node_modules/http-cookie-agent": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/http-cookie-agent/-/http-cookie-agent-1.0.5.tgz",
+      "integrity": "sha512-X8QM/rGPu/cb7A37uNLuz+PZfkmlQ9PycDD+/QsmqICXBd9grKWdWKMzg/BDkzxIbV+P/FYTsKZn08KcXgbLsQ==",
+      "dependencies": {
+        "agent-base": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=12.19.0 <13.0.0 || >=14.5.0"
+      },
+      "peerDependencies": {
+        "tough-cookie": "^4.0.0"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
@@ -3328,14 +3312,6 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true
-    },
-    "node_modules/is-redirect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/is-regex": {
       "version": "1.1.4",
@@ -4488,8 +4464,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -7175,7 +7150,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
       "requires": {
         "debug": "4"
       }
@@ -7303,22 +7277,6 @@
       "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
       "requires": {
         "follow-redirects": "^1.14.8"
-      }
-    },
-    "axios-cookiejar-support": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/axios-cookiejar-support/-/axios-cookiejar-support-1.0.1.tgz",
-      "integrity": "sha512-IZJxnAJ99XxiLqNeMOqrPbfR7fRyIfaoSLdPUf4AMQEGkH8URs0ghJK/xtqBsD+KsSr3pKl4DEQjCn834pHMig==",
-      "requires": {
-        "is-redirect": "^1.0.0",
-        "pify": "^5.0.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-5.0.0.tgz",
-          "integrity": "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA=="
-        }
       }
     },
     "babel-jest": {
@@ -7617,7 +7575,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
       "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-      "dev": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -8591,6 +8548,14 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
+    "http-cookie-agent": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/http-cookie-agent/-/http-cookie-agent-1.0.5.tgz",
+      "integrity": "sha512-X8QM/rGPu/cb7A37uNLuz+PZfkmlQ9PycDD+/QsmqICXBd9grKWdWKMzg/BDkzxIbV+P/FYTsKZn08KcXgbLsQ==",
+      "requires": {
+        "agent-base": "^6.0.2"
+      }
+    },
     "http-proxy-agent": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
@@ -8793,11 +8758,6 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true
-    },
-    "is-redirect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
     },
     "is-regex": {
       "version": "1.1.4",
@@ -9688,8 +9648,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "natural-compare": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "database"
   ],
   "dependencies": {
+    "http-cookie-agent": "^1.0.5",
     "@types/tough-cookie": "^4.0.0",
     "axios": "^0.26.1",
-    "axios-cookiejar-support": "^1.0.1",
     "qs": "^6.10.3",
     "tough-cookie": "^4.0.0"
   },

--- a/test/nano.auth.test.js
+++ b/test/nano.auth.test.js
@@ -24,8 +24,8 @@ test('should be able to authenticate - POST /_session - nano.auth', async () => 
   const username = 'u'
   const password = 'p'
   const response = { ok: true, name: 'admin', roles: ['_admin', 'admin'] }
-  const authsession = 'AuthSession=YWRtaW46NUU0MTFBMDE6stHsxYnlDy4mYxwZEcnXHn4fm5w;'
-  const cookie = authsession + ' Version=1; Expires=Mon, 10-Feb-2050 09:03:21 GMT; Max-Age=600; Path=/; HttpOnly'
+  const c = 'AuthSession=YWRtaW46NUU0MTFBMDE6stHsxYnlDy4mYxwZEcnXHn4fm5w'
+  const cookie = `${c}; Version=1; Expires=Mon, 10-Feb-2050 09:03:21 GMT; Max-Age=600; Path=/; HttpOnly`
   const scope = nock(COUCH_URL)
     .post('/_session', 'name=u&password=p', { 'content-type': 'application/x-www-form-urlencoded; charset=utf-8' })
     .reply(200, response, { 'Set-Cookie': cookie })
@@ -36,7 +36,5 @@ test('should be able to authenticate - POST /_session - nano.auth', async () => 
   const p = await nano.auth(username, password)
   expect(p).toStrictEqual(response)
   await nano.db.list()
-  expect(nano.config.cookies.length).toBe(1)
-  expect(nano.config.cookies[0].toString().startsWith(authsession)).toBe(true)
   expect(scope.isDone()).toBe(true)
 })


### PR DESCRIPTION
## Overview

Removes `axios-cookiejar-support` and replaces it with `http-cookie-agent`, which is basically the same logic but it works with our custom http/https agents.

This means that 

- issue #295 gets fixed - we no longer need to pull in the latest axios-cookiejar-support
- issue #264 goes away

## Testing recommendations

- `npm run test` all passes
- I manually checked that Nano stores and replays cookies sent to it from the server

## GitHub issue number

Fixes  issue #295

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [x] Documentation reflects the changes;
