### PR TITLE
callback javascript errors instead of objects

### DIFF
--- a/lib/nano.js
+++ b/lib/nano.js
@@ -137,11 +137,9 @@ module.exports = exports = function dbScope (cfg) {
         reject(new Error(`error happened in your connection. Reason: ${response.message}`))
       }
       if (callback) {
-        const returnError = {
-          message: `error happened in your connection. Reason: ${response.message}`,
-          scope: 'socket',
-          errid: 'request'
-        }
+        const returnError = new Error(`error happened in your connection. Reason: ${response.message}`)
+        returnError.scope = 'socket'
+        returnError.errid = 'request'
         callback(returnError)
       }
       return


### PR DESCRIPTION
## Overview

When using the callback api, if the connection fails, an object is returned (callback) instead of an error. 
Why is this a problem: because the error will not have a stack trace.

## Testing recommendations


## Checklist

- [x ] Code is written and works correctly;
- N/A Changes are covered by tests;
- N/A Documentation reflects the changes;
