### PR TITLE
Add head response type

### DIFF
--- a/lib/nano.d.ts
+++ b/lib/nano.d.ts
@@ -338,7 +338,7 @@ declare namespace nano {
     get(docname: string, params?: DocumentGetParams, callback?: Callback<DocumentGetResponse & D>): Promise<DocumentGetResponse & D>;
     /** Fetch document meta data, useful for fetching a document's current revision.
      * @see Docs: {@link http://docs.couchdb.org/en/latest/api/document/common.html#head--db-docid} */
-    head(docname: string, callback?: Callback<any>): Promise<any>;
+    head(docname: string, callback?: Callback<DocumentHeadResponseHeaders>): Promise<DocumentHeadResponseHeaders>;
     /** Delete a document from this database.
      * @see Docs: {@link http://docs.couchdb.org/en/latest/api/document/common.html#delete--db-docid} */
     destroy(docname: string, rev: string, callback?: Callback<DocumentDestroyResponse>): Promise<DocumentDestroyResponse>;
@@ -1247,6 +1247,13 @@ declare namespace nano {
      *
      * Available if requested with revs=true query parameter. */
     _revisions?: any;
+  }
+
+  /** Document head response headers:
+   * @see docs: {@link https://docs.couchdb.org/en/latest/api/document/common.html#head--db-docid} */
+  interface DocumentHeadResponseHeaders {
+    /** Double quoted document’s revision token. */
+    etag: string;
   }
 
   /** _all_docs parameters


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Defines the return type of `head`.

Does not include `content-length` property since it is not returned by nano (see #301).

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [x] Documentation reflects the changes;
