### PR TITLE
fix typing of 'since' options

### DIFF
--- a/lib/nano.d.ts
+++ b/lib/nano.d.ts
@@ -248,7 +248,7 @@ declare namespace nano {
     /** whether to get a faster changes feed by supplying 'seq_interval'   */
     fastChanges?: boolean;
     /** where to begin the changes feed: 0, now or a sequence token */
-    since?: string;
+    since?: string | number;
     /** whether to return document bodies too */
     includeDocs?: boolean;
     /** number of milliseconds when the longpoll request will timeout */
@@ -965,7 +965,7 @@ declare namespace nano {
      * Can be valid update sequence or now value.
      *
      * @default 0 */
-    since?: number;
+    since?: string | number;
 
     /** Specifies how many revisions are returned in the changes array.
      * 


### PR DESCRIPTION
This is a quick win. `since` can take a `seq` or `"now"` (which are both strings) in addition to `0` (the beginning of time, `"0"` also works).