### PR TITLE
Changed datatype of update_seq and pure_seq to be `number | string`

### DIFF
--- a/lib/nano.d.ts
+++ b/lib/nano.d.ts
@@ -778,7 +778,7 @@ declare namespace nano {
     instance_start_time: string;
 
     /** The number of purge operations on the database. */
-    purge_seq: number;
+    purge_seq: number | string;
 
     sizes: {
       /** The size of live data inside the database, in bytes. */
@@ -792,7 +792,7 @@ declare namespace nano {
     };
 
     /** The current number of updates to the database. */
-    update_seq: number;
+    update_seq: number | string;
   }
 
   /** OK response
@@ -1347,7 +1347,7 @@ declare namespace nano {
     total_rows: number;
 
     /** Current update sequence for the database. */
-    update_seq?: number;
+    update_seq?: number | string;
   }
 
   /** Fetch with POST _all_docs parameters.
@@ -1381,7 +1381,7 @@ declare namespace nano {
     offset: number;
     rows: Array<DocumentResponseRow<D> | DocumentLookupFailure>;
     total_rows: number;
-    update_seq?: number;
+    update_seq?: number | string;
   }
 
   /** Fetch revisions response
@@ -1390,7 +1390,7 @@ declare namespace nano {
     offset: number;
     rows: Array<DocumentResponseRow<D> | DocumentLookupFailure>;
     total_rows: number;
-    update_seq?: number;
+    update_seq?: number | string;
   }
 
   /** Search response


### PR DESCRIPTION
## Overview
The datatype of `udpate_seq` and `purge_seq` in actual response object from CouchDB is `string` but in the nano library it is defined as `number`. This PR tries to fix this issue. See issue #316 for more details.

## Testing recommendations
Run nano against older and newer versions of apache couchdb to validate the datatype in actual response object vs the one defined in nano.d.ts.
Also please check if the doc-comments for the fields are correct or not as they are like below:
```typescript
/** The number of purge operations on the database. */
purge_seq: number | string;
```
I am not sure if changing the description to be something like `The sequence ID of purge operations on the database.` i.e. if calling it ID instead of number is appropriate or not.

## GitHub issue number
Fixes #316 

## Checklist

- [ x ] Code is written and works correctly;
- [ x ] Changes are covered by tests;
- [ x ] Documentation reflects the changes;
