### PR TITLE
Deprecating credentials in url

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ To use `nano` you need to connect it to your CouchDB install, to do that:
 const nano = require('nano')('http://localhost:5984');
 ```
 
-> Note: The URL you supply may also contain authentication credentials e.g. `http://admin:mypassword@localhost:5984`.
+> Note: Supplying authentication credentials in the URL e.g. `http://admin:mypassword@localhost:5984` is deprecated. Use `nano.auth` instead.
 
 To create a new database:
 


### PR DESCRIPTION
## Overview

This is a follow up for https://github.com/apache/couchdb-nano/issues/174
Docs should stop suggesting the `http://username:password@127.0.0.1:5984` syntax for connection and suggest using `.auth` instead.

## Testing recommendations

I'm not sure yet if we only have to update readme.md, but at least going through it with a simple search for `pass` is helpful to find other places to be modified.

## Checklist

- [ ] check whether there's any related PRs;
- [ ] check if docs are stored in other places than readme.md;
- [ ] find all the places to be rewritten;
- [ ] update content.
