### PR TITLE
docs: correct db.destroy description

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,7 +541,7 @@ const response = await alice.insert({ _id: 'myid', _rev: '1-23202479633c2b380f79
 
 ### db.destroy(docname, rev, [callback])
 
-Removes a document from CouchDB whose `_id` is `docname` and who's revision is `_rev`:
+Removes a document from CouchDB whose `_id` is `docname` and who's revision (`_rev`) is `rev`:
 
 ```js
 const response = await alice.destroy('rabbit', '3-66c01cdf99e84c83a9b3fe65b88db8c0')

--- a/README.md
+++ b/README.md
@@ -541,7 +541,7 @@ const response = await alice.insert({ _id: 'myid', _rev: '1-23202479633c2b380f79
 
 ### db.destroy(docname, rev, [callback])
 
-Removes a document from CouchDB whose `_id` is `docname` and who's revision (`_rev`) is `rev`:
+Removes a document from CouchDB whose `_id` is `docname` and whose revision (`_rev`) is `rev`:
 
 ```js
 const response = await alice.destroy('rabbit', '3-66c01cdf99e84c83a9b3fe65b88db8c0')


### PR DESCRIPTION
The current description of `db.destroy` mixes up `_rev` (referring to where revision is stored) and `rev` (the function argument). This small change is to sort things out.