### PR TITLE
Capture error message, otherwise capture cause of HTTP failure

### DIFF
--- a/lib/nano.js
+++ b/lib/nano.js
@@ -128,7 +128,7 @@ module.exports = exports = function dbScope (cfg) {
       statusCode
     }, response.headers ? response.headers : {})
     if (!response.status) {
-      response.statusText = response.cause.toString()
+      response.statusText = response.message ?? response.cause?.toString()
       log({ err: 'socket', body, headers: responseHeaders })
       if (reject) {
         reject(new Error(`error happened in your connection. Reason: ${response.statusText}`))

--- a/lib/nano.js
+++ b/lib/nano.js
@@ -122,17 +122,18 @@ module.exports = exports = function dbScope (cfg) {
       }
     }
 
-    // let parsed
-    const responseHeaders = Object.assign({
+    const responseHeaders = {
       uri: scrubURL(req.url),
-      statusCode
-    }, response.headers ? response.headers : {})
+      statusCode,
+      ...(response.headers ?? {})
+    };
+  
     if (!response.status) {
-      // since #relax might have sent Error rather than Response:
-      response.statusText = response.message ?? response.cause?.toString()
       log({ err: 'socket', body, headers: responseHeaders })
       if (reject) {
-        reject(new Error(`error happened in your connection. Reason: ${response.statusText}`))
+        // since #relax might have sent Error rather than Response:
+        const statusText = response.cause?.toString() ?? response.message
+        reject(new Error(`error happened in your connection. Reason: ${statusText}`))
       }
       return
     }

--- a/lib/nano.js
+++ b/lib/nano.js
@@ -128,6 +128,7 @@ module.exports = exports = function dbScope (cfg) {
       statusCode
     }, response.headers ? response.headers : {})
     if (!response.status) {
+      // since #relax might have sent Error rather than Response:
       response.statusText = response.message ?? response.cause?.toString()
       log({ err: 'socket', body, headers: responseHeaders })
       if (reject) {


### PR DESCRIPTION
One approach to apache/couchdb-nano#356; refactor likely needed ( along with #355 ) to wring out design errors.

## Overview

Intended to resolve #356 

That was originally seen as fixing a syntax error, but the syntax error existed because of a theory error.

By that theory error, when an `Error` was thrown on a request, the message is being lost.

## Reasoning

This has already met `!response.status` which means it is more than likely `error` and not `response` being called `response` due to the theory error, since the design does not have a separate `responseHandler` for errors.

Because of that, I check `response.message` first, then `response.cause?.toString()` ( includes fix requested by #356 )

## Testing recommendations

- [x] Use with no server online ( per https://github.com/apache/couchdb-nano/issues/356#issuecomment-3287835196 case )

---

Since this is a small change of one line ... but might trigger a refactor since there is a theory error still:

- [x] No documentation change required
- [ ] Putting this out there for discussion first
- [x] Have run this in my environment
- [ ] May need a test added, triggering error
- [ ] Refactor likely needed which might invalidate