### PR TITLE
added missing TypeScript definition for findAsStream

### DIFF
--- a/lib/nano.d.ts
+++ b/lib/nano.d.ts
@@ -550,6 +550,9 @@ declare namespace nano {
     /** Run Mango query.
      * @see Docs: {@link http://docs.couchdb.org/en/latest/api/database/find.html#db-find} */
     find(query: MangoQuery): Promise <MangoResponse<D>>;
+    /** Run Mango query as a stream.
+     * @see Docs: {@link http://docs.couchdb.org/en/latest/api/database/find.html#db-find} */
+    findAsStream(query: MangoQuery): NodeJS.ReadStream;
     /** Server scope */
     server: ServerScope;
     /** Fetch information about a single partition in this database.


### PR DESCRIPTION
## Overview

No code changes, just fixes a missing TypeScript definition for the `findAsStream` function.

## Testing recommendations

Passes TypeScript tests.

```sh
tsc lib/nano.d.ts 
```

## GitHub issue number

Fixes https://github.com/apache/couchdb-nano/issues/360

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [x] Documentation reflects the changes;
