### PR TITLE
Ensure that all application/json responses are parsed as JSON

### DIFF
--- a/lib/nano.js
+++ b/lib/nano.js
@@ -148,7 +148,7 @@ module.exports = exports = function dbScope (cfg) {
       // when doing head requests, we return the response headers, not the response body
       if (req.method === 'head') {
         retval = Object.fromEntries(response.headers)
-      } else if (contentType === 'application/json') {
+      } else if (contentType && contentType.startsWith('application/json')) {
         try {
           retval = await response.json()
         } catch {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,28 +9,28 @@
       "version": "11.0.4",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@types/node": "^25.2.1",
-        "typescript": "^5.9.3",
-        "undici": "^7.20.0"
+        "@types/node": "^25.5.0",
+        "typescript": "^6.0.2",
+        "undici": "^7.24.6"
       },
       "engines": {
         "node": ">=20.0"
       }
     },
     "node_modules/@types/node": {
-      "version": "25.2.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.1.tgz",
-      "integrity": "sha512-CPrnr8voK8vC6eEtyRzvMpgp3VyVRhgclonE7qYi6P9sXwYb59ucfrnmFBTaP0yUi8Gk4yZg/LlTJULGxvTNsg==",
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
+      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -42,9 +42,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.0.tgz",
-      "integrity": "sha512-jxytwMHhsbdpBXxLAcuu0fzlQeXCNnWdDyRHpvWsUl8vd98UwYdl9YTyn8/HcpcJPC3pwUveefsa3zTxyD/ERg==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.6.tgz",
+      "integrity": "sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -52,9 +52,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     }

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
   "dependencies": {
   },
   "devDependencies": {
-    "undici": "^7.20.0",
-    "@types/node": "^25.2.1",
-    "typescript": "^5.9.3"
+    "undici": "^7.24.6",
+    "@types/node": "^25.5.0",
+    "typescript": "^6.0.2"
   },
   "scripts": {
     "test": "tsc lib/nano.d.ts && node --test ./test/*.test.js"

--- a/test/nano.request.test.js
+++ b/test/nano.request.test.js
@@ -442,3 +442,25 @@ test('check request sends headers for gzipped responses - nano.request', async (
   assert.deepEqual(p, response)
   mockAgent.assertNoPendingInterceptors()
 })
+
+
+test('check request parses JSON with character set', async () => {
+  // mocks
+  const response = { ok: true }
+  const CHARSET_HEADERS = { headers: { 'content-type': 'application/json; charset=utf-8' } }
+  mockPool
+    .intercept({
+      path: '/db/mydoc'
+    })
+    .reply(200, response, CHARSET_HEADERS)
+
+  // test GET /db?a=1&b=2
+  const req = {
+    method: 'get',
+    db: 'db',
+    doc: 'mydoc'
+  }
+  const p = await nano.request(req)
+  assert.deepEqual(p, response)
+  mockAgent.assertNoPendingInterceptors()
+})


### PR DESCRIPTION
## Overview

Issue #366 reported that a content-type of `application/json; charset=utf-8` was not being parsed as json. This PR fixes that.

## Testing recommendations

Automated test added to try a content-type with a charset.

## GitHub issue number

Fixes issue #366.

## Related Pull Requests

n/a

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [x] Documentation reflects the changes;
