### PR TITLE
Missing new_edits flag in bulk docs body (TypeScript definition)

### DIFF
--- a/lib/nano.d.ts
+++ b/lib/nano.d.ts
@@ -702,6 +702,7 @@ declare namespace nano {
 
   interface BulkModifyDocsWrapper {
     docs: any[];
+    new_edits?: boolean;
   }
 
   interface BulkFetchDocsWrapper {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,28 +9,28 @@
       "version": "11.0.5",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@types/node": "^25.5.0",
-        "typescript": "^6.0.2",
-        "undici": "^7.24.6"
+        "@types/node": "^26.1.0",
+        "typescript": "^6.0.3",
+        "undici": "^7.28.0"
       },
       "engines": {
         "node": ">=20.0"
       }
     },
     "node_modules/@types/node": {
-      "version": "25.5.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
-      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
+      "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/typescript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
-      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -42,9 +42,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.6.tgz",
-      "integrity": "sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -52,9 +52,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     }

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
   "dependencies": {
   },
   "devDependencies": {
-    "undici": "^7.24.6",
-    "@types/node": "^25.5.0",
-    "typescript": "^6.0.2"
+    "undici": "^7.28.0",
+    "@types/node": "^26.1.0",
+    "typescript": "^6.0.3"
   },
   "scripts": {
     "test": "tsc lib/nano.d.ts && node --test ./test/*.test.js"


### PR DESCRIPTION
## Overview

- fixes omission of `new_edits` in bulk docs body TypeScript definition
- bump dependecies - note-to-self: cannot bump to latest Undici as it has broken mocking of fetch calls https://github.com/nodejs/undici/pull/5448

## Testing recommendations

```sh
npm run test
```

- TypeScript is valid.
- Tests pass

## GitHub issue number

Fixes #370

## Checklist

- [x] Code is written and works correctly;

